### PR TITLE
feat: add domain io

### DIFF
--- a/src/fourcipp/legacy_io/domain.py
+++ b/src/fourcipp/legacy_io/domain.py
@@ -1,0 +1,75 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2025 FourCIPP Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""Domain io.
+
+Once this section is implemented in 4C using InputSpec, this file can be
+deleted.
+"""
+
+from functools import partial
+
+from fourcipp.legacy_io.inline_dat import (
+    _extract_all,
+    _extract_enum,
+    _extract_vector,
+    inline_dat_read,
+    to_dat_string,
+)
+
+DOMAIN_CASTING = {
+    "LOWER_BOUND": partial(_extract_vector, entry_type=float, size=3),
+    "UPPER_BOUND": partial(_extract_vector, entry_type=float, size=3),
+    "INTERVALS": partial(_extract_vector, entry_type=int, size=3),
+    "ROTATION": partial(_extract_vector, entry_type=float, size=3),
+    "ELEMENTS": partial(_extract_all, entry_type=str),
+    "PARTITION": partial(_extract_enum, choices=["auto", "structured"]),
+}
+
+
+def read_domain(lines):
+    """Read domain section.
+
+    Args:
+        lines (list): List of lines.
+
+    Returns:
+        dict: Domain section as dict
+    """
+    data = {}
+    for line in lines:
+        data.update(inline_dat_read(line.split(), DOMAIN_CASTING))
+    return data
+
+
+def write_domain(domain):
+    """Write domain section.
+
+    Args:
+        domain (dict): Domain section as dict
+
+    Returns:
+        list: Domain as list of lines
+    """
+    new_lines = []
+    for k, v in domain.items():
+        new_lines.append(f"{k} {to_dat_string(v)}")
+    return new_lines

--- a/src/fourcipp/legacy_io/inline_dat.py
+++ b/src/fourcipp/legacy_io/inline_dat.py
@@ -86,6 +86,19 @@ def _extract_vector(line_list, entry_type, size):
     return [entry_type(e) for e in _left_pop(line_list, size)]
 
 
+def _extract_all(line_list, entry_type):
+    """Extract all the entries from a line list.
+
+    Args:
+        line_list (list): List to extract the entries
+        entry_type (callable): Function to cast the string into the desired object
+
+    Returns:
+        list: Casted vector object
+    """
+    return [entry_type(e) for e in _left_pop(line_list, len(line_list))]
+
+
 def _extract_enum(line_list, choices):
     """Extract enum entry from a line list.
 

--- a/tests/fourcipp/legacy_io/test_domain.py
+++ b/tests/fourcipp/legacy_io/test_domain.py
@@ -1,0 +1,46 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2025 FourCIPP Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""Test domain io."""
+
+import pytest
+
+from fourcipp.legacy_io.domain import read_domain, write_domain
+
+
+@pytest.fixture(name="reference_domain_lines")
+def fixture_reference_domain_lines():
+    """Reference lines."""
+    return [
+        "LOWER_BOUND 0.1 0.1  0.1",
+        "UPPER_BOUND 0.1 0.1  0.1",
+        "INTERVALS 10 12 13",
+        "ROTATION 0.1 0.2 0.3",
+        "PARTITION auto",
+        "ELEMENTS some  string ",
+    ]
+
+
+def test_domains_read_and_write(reference_domain_lines):
+    """Test read and write domain."""
+    lines = write_domain(read_domain(reference_domain_lines))
+    for k in range(len(reference_domain_lines)):
+        assert reference_domain_lines[k].split() == lines[k].split()


### PR DESCRIPTION
This PR adds the ability to read and write the domain section.

For now, this is hard-coded, once this information is in the metadata file, this code becomes obsolete.

Note: currently, this change cannot be done in 4C since `LOWER_BOUND` are vectors that dat can not handle. Once more, it highlights the benefits of changing to YAML.