### PR TITLE
refactor: change yaml reader

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,3 @@
-ruamel.yaml
+rapidyaml
 jsonschema
 loguru

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,17 @@ attrs==25.3.0
     # via
     #   jsonschema
     #   referencing
+deprecation==2.1.0
+    # via rapidyaml
 jsonschema==4.23.0
     # via -r requirements.in
 jsonschema-specifications==2024.10.1
     # via jsonschema
 loguru==0.7.3
+    # via -r requirements.in
+packaging==24.2
+    # via deprecation
+rapidyaml==0.8.0
     # via -r requirements.in
 referencing==0.36.2
     # via
@@ -22,9 +28,5 @@ rpds-py==0.23.1
     # via
     #   jsonschema
     #   referencing
-ruamel-yaml==0.18.10
-    # via -r requirements.in
-ruamel-yaml-clib==0.2.12
-    # via ruamel-yaml
 typing-extensions==4.12.2
     # via referencing

--- a/src/fourcipp/utils/yaml_io.py
+++ b/src/fourcipp/utils/yaml_io.py
@@ -21,17 +21,29 @@
 # THE SOFTWARE.
 """YAML io."""
 
-from pathlib import Path
+import json
+import pathlib
 
-import ruamel.yaml
-
-_YAML = ruamel.yaml.YAML()
+import ryml
 
 
-def load_yaml(path_to_input_file):
-    """Load 4C yaml input files.
+def load_yaml(path_to_yaml_file):
+    """Load yaml files.
+
+    rapidyaml is the fastest yaml parsing library we could find. Since it returns custom objects we
+    use the library to emit the objects to json and subsequently read it in using the json library.
+    This is still two orders of magnitude faster compared to other yaml libraries.
 
     Args:
-        path_to_input_file (str): Path to input file
+        path_to_yaml_file (str): Path to yaml file
+
+    Returns:
+        dict: Loaded data
     """
-    return _YAML.load(Path(path_to_input_file))
+
+    data = json.loads(
+        ryml.emit_json(
+            ryml.parse_in_arena(pathlib.Path(path_to_yaml_file).read_bytes())
+        )
+    )
+    return data


### PR DESCRIPTION
As mentioned in my [comment](https://github.com/4C-multiphysics/fourcipp/pull/3#issuecomment-2753887609), reading in the metadata file was quite slow. As I mentioned, this could be fixed, following the spirit _Big  O is for Big N_.

Timing comparison to read in the metadata file for different yaml readers/approach:

|YAML reading| time in seconds|
|---|---|
|ruaml.yaml (currently)| 5.163100043020677|
|pyyaml | 2.591309632989578|
|rapidyaml (custom objects)| 0.024680914008058608|
|rapidyaml->json->python dicts| 0.029835978988558054|

We, of course, went for the last approach, such that we now are definitely below the arbitrary overhead of 0.1s asked for by @isteinbrecher.

Sidenotes:
- Converting the metadata file to json and then reading it in with a json library: 0.007s (I only timed the reading in)
- credits to @sebproell, he introduced rapidyaml in 4C :)