### PR TITLE
feat: add header read only

### DIFF
--- a/src/fourcipp/fourc_input.py
+++ b/src/fourcipp/fourc_input.py
@@ -80,16 +80,21 @@ class FourCInput:
                 self.__setitem__(k, v)
 
     @classmethod
-    def from_4C_yaml(cls, input_file_path):
+    def from_4C_yaml(cls, input_file_path, header_only=False):
         """Load 4C yaml file.
 
         Args:
-            input_file_path (str): Path to yaml file.
+            input_file_path (str): Path to yaml file
+            header_only (bool): Only extract header, i.e., all sections except the legacy ones
 
         Returns:
             FourCInputFile: Initialised object
         """
-        return cls(load_yaml(input_file_path))
+        data = load_yaml(input_file_path)
+        if header_only:
+            for section in LEGACY_SECTIONS:
+                data.pop(section, None)
+        return cls(data)
 
     @property
     def inlined(self):
@@ -388,3 +393,11 @@ class FourCInput:
             raise TypeError(f"Can not compare types {type(self)} and {type(other)}")
 
         return self.sections == other.sections
+
+    def extract_header(self):
+        """Extract the header sections, i.e., all non-legacy sections.
+
+        Returns:
+            FourCInput: Input with only the non-legacy sections
+        """
+        return FourCInput(sections=self._sections)

--- a/tests/fourcipp/legacy_io/test_element.py
+++ b/tests/fourcipp/legacy_io/test_element.py
@@ -59,15 +59,11 @@ def inline_element_from_cell(cell_spec, element_type):
     """
     cells = []
 
-    if (
-        len(cell_spec["specs"]) == 1
-        and (spec := cell_spec["specs"][0])["type"] == "one_of"
-    ):
-        for one_of_branch in spec["specs"]:
+    if cell_spec["type"] == "one_of":
+        for one_of_branch in cell_spec["specs"]:
             cells.append(inline_element_from_spec(one_of_branch, element_type))
     else:
-        for spec in cell_spec["specs"]:
-            cells.append(inline_element_from_spec(spec, element_type))
+        cells.append(inline_element_from_spec(cell_spec, element_type))
 
     return cells
 
@@ -81,16 +77,17 @@ def generate_elements_from_metadatafile():
     data = CONFIG["4C_metadata"]["legacy_element_specs"]["specs"]
 
     elements = []
-    for element in data:
-        element_type = element.get("name", "")
+    for element_groups in data:
+        for element in element_groups["specs"]:
+            element_type = element.get("name", "")
 
-        # Positional parameters are handled differently
-        if element_type.startswith("_positional_"):
-            continue
+            # Positional parameters are handled differently
+            if element_type.startswith("_positional_"):
+                continue
 
-        # Loop over all elements
-        for ele in element["specs"]:
-            elements.extend(inline_element_from_cell(ele, ele["name"]))
+            # Loop over all elements
+            for ele in element["specs"]:
+                elements.extend(inline_element_from_cell(ele, element["name"]))
     return elements
 
 

--- a/tests/fourcipp/test_fourc_input.py
+++ b/tests/fourcipp/test_fourc_input.py
@@ -65,6 +65,18 @@ def fixture_fourc_input(section_names, dummy_data):
     return fourc_input
 
 
+@pytest.fixture(name="fourc_input_with_legacy_section")
+def fixture_fourc_input_with_legacy_section(fourc_input):
+    """Input object with a legacy section."""
+    # Copy the input
+    new_input = fourc_input.copy()
+
+    # Add a legacy section
+    new_input["DNODE-NODE TOPOLOGY"] = ["NODE 1 DNODE 1"]
+
+    return new_input
+
+
 @pytest.fixture(name="fourc_input_2")
 def fixture_fourc_input_2(section_names_2, dummy_data):
     """Second input object."""
@@ -319,3 +331,30 @@ def test_roundtrip_test(fourc_file, tmp_path):
         raise Exception(
             f"Input file failed for {fourc_file}.\n\n4C command: {command}\n\nOutput: {tmp_path / 'output.log'}"
         )
+
+
+def test_extract_header_sections(fourc_input, fourc_input_with_legacy_section):
+    """Test the header extraction."""
+
+    # Extract the header
+    header = fourc_input_with_legacy_section.extract_header()
+
+    assert header == fourc_input
+
+
+def test_load_from_yaml(fourc_input_with_legacy_section, tmp_path):
+    """Test load from yaml file."""
+    path_to_yaml = tmp_path / "fourc_input.4C.yaml"
+    fourc_input_with_legacy_section.dump(path_to_yaml)
+
+    assert fourc_input_with_legacy_section == FourCInput.from_4C_yaml(path_to_yaml)
+
+
+def test_load_from_yaml_header_only(
+    fourc_input, fourc_input_with_legacy_section, tmp_path
+):
+    """Test load from yaml file using header only."""
+    path_to_yaml = tmp_path / "fourc_input.4C.yaml"
+    fourc_input_with_legacy_section.dump(path_to_yaml)
+
+    assert fourc_input == FourCInput.from_4C_yaml(path_to_yaml, header_only=True)


### PR DESCRIPTION
This PR adds the functionality to extract only the header sections from a YAML file, avoiding interpreting the legacy section if desired.