### PR TITLE
refactor: change config setup

### DIFF
--- a/.github/workflows/run_testsuite.yaml
+++ b/.github/workflows/run_testsuite.yaml
@@ -33,5 +33,11 @@ jobs:
         run: |
           conda activate fourcipp
           pip install -e .[dev]
-      - name: Run run_pytest
-        run: pytest --color=yes -v
+      - name: Run pytest using 4C_docker_main config
+        run: |
+          fourcipp-switch-profile 4C_docker_main
+          pytest --color=yes -v
+      - name: Run pytest using default config
+        run: |
+          fourcipp-switch-profile default
+          pytest --color=yes -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,11 @@ authors = [{ name = "FourCIPP Authors" }]
 description = "A streamlined Python Parser for 4C input files"
 readme = "README.md"
 license = { file = "LICENSE" }
-
 requires-python = "==3.12.*"
 dynamic = ["dependencies"]
+
+[project.scripts]
+fourcipp-switch-profile = "fourcipp.utils.configuration:change_profile_cli"
 
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }

--- a/src/fourcipp/config/config.yaml
+++ b/src/fourcipp/config/config.yaml
@@ -1,7 +1,10 @@
+profile: default
 profiles:
-  default: # Nightly updated metadata and schema file in fourcipp
-    4C_metadata_path: src/fourcipp/config/4C_metadata.yaml
-    json_schema_path: src/fourcipp/config/4C_schema.json
-  testing: # Paths in 4C docker image
+  default:
+    4C_metadata_path: 4C_metadata.yaml
+    json_schema_path: 4C_schema.json
+    description: 4C metadata from the latest successful nightly 4C build
+  4C_docker_main:
     4C_metadata_path: /home/user/4C/build/4C_metadata.yaml
     json_schema_path: /home/user/4C/build/4C_schema.json
+    description: 4C metadata in the main 4C docker image

--- a/tests/fourcipp/test_fourc_input.py
+++ b/tests/fourcipp/test_fourc_input.py
@@ -311,7 +311,9 @@ class SubprocessError(Exception):
     """Subprocess failure."""
 
 
-@pytest.mark.skipif(not FOURC_TEST_INPUT_FILES, reason="4C input files not found.")
+@pytest.mark.skipif(
+    CONFIG["profile"] != "4C_docker_main", reason="Not using docker config."
+)
 @pytest.mark.xfail(raises=SubprocessError)
 @pytest.mark.parametrize("fourc_file", FOURC_TEST_INPUT_FILES)
 def test_roundtrip_test(fourc_file, tmp_path):

--- a/tests/fourcipp/utils/test_configuration.py
+++ b/tests/fourcipp/utils/test_configuration.py
@@ -19,23 +19,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-"""FourCIPP."""
+"""Test configuration utils."""
 
-from loguru import logger
+import pytest
 
-from fourcipp.utils.configuration import load_config, profile_description
+from fourcipp.utils.configuration import _change_profile, list_profiles
 
-# Disable FourCIPP logging by default if desired enable it in your own project
-logger.disable("fourcipp")
 
-# Load the config
-CONFIG = load_config()
-
-DESCRIPTION_SECTION = CONFIG["4C_metadata"]["metadata"]["description_section_name"]
-SECTIONS = [section["name"] for section in CONFIG["4C_metadata"]["sections"]] + [
-    DESCRIPTION_SECTION
-]
-LEGACY_SECTIONS = list(CONFIG["4C_metadata"]["legacy_string_sections"])
-ALL_SECTIONS = sorted(SECTIONS + LEGACY_SECTIONS)
-
-logger.info(profile_description())
+def test_change_profile_failure():
+    """Test for change profile failure."""
+    with pytest.raises(Exception, match="Profile"):
+        _change_profile("non-existing")


### PR DESCRIPTION
This PR simplifies the config setup.

This means that to use FourCIPP, you have to set the config.yaml file by:
- Listing all available profiles in the `profiles` section
- Selecting which one you are using using the `profile` key

Note: Relative paths are expected to be w.r.t. to `src/fourcipp/config/`

I added a CLI `fourcipp-switch-profile` to make it easier to switch between profiles.

Both profiles are run in the pipeline.