### PR TITLE
feat: add section validation only

### DIFF
--- a/src/fourcipp/fourc_input.py
+++ b/src/fourcipp/fourc_input.py
@@ -334,13 +334,22 @@ class FourCInput:
 
         dump_yaml(self.inlined, input_file_path, sort_sections)
 
-    def validate(self, json_schema=CONFIG["json_schema"]):
+    def validate(self, json_schema=CONFIG["json_schema"], sections_only=False):
         """Validate input file.
 
         Args:
             json_schema (dict): Schema to check the data
+            sections_only (bool): Validate each section independently. Requiredness of the sections
+                                  themselves is ignored.
         """
-        return validate_using_json_schema(self.inlined, json_schema)
+        validation_schema = json_schema
+
+        # Remove the requiredness of the sections
+        if sections_only:
+            validation_schema = json_schema.copy()
+            validation_schema.pop("required")
+
+        return validate_using_json_schema(self.inlined, validation_schema)
 
     def split(self, section_names):
         """Split input into two using sections names.

--- a/src/fourcipp/utils/validation.py
+++ b/src/fourcipp/utils/validation.py
@@ -22,6 +22,7 @@
 """Validation utils."""
 
 import jsonschema_rs
+from jsonschema_rs import ValidationError as FourCIPPValidationError
 
 
 def validate_using_json_schema(data, json_schema):


### PR DESCRIPTION
This PR adds the functionality to validate each section independently, whether they are required or not. This is important in a setting where you want to only validate part of the data.

@dragos-ana @davidrudlstorfer 