### PR TITLE
fix: use join to combine input with dicts

### DIFF
--- a/src/fourcipp/fourc_input.py
+++ b/src/fourcipp/fourc_input.py
@@ -220,8 +220,7 @@ class FourCInput:
             sections (dict, FourCInput): Sections to be updated
         """
         if isinstance(sections, dict):
-            for k, v in sections.items():
-                self[k] = v
+            self.join(FourCInput(sections))
         elif isinstance(sections, FourCInput):
             self.join(sections)
         else:


### PR DESCRIPTION
This PR adds a check to see if sections were already present in the source and destination objects.

@davidrudlstorfer could you check if this fixes your problem?