### PR TITLE
Fix NURBS input for single given dimension

### DIFF
--- a/src/fourcipp/legacy_io/knotvectors.py
+++ b/src/fourcipp/legacy_io/knotvectors.py
@@ -27,7 +27,6 @@ from fourcipp.legacy_io.inline_dat import _extract_entry, _extract_enum, _extrac
 
 NURBS_PATCH_CASTING = {
     "ID": partial(_extract_entry, entry_type=int),
-    "NURBS_DIMENSION": partial(_extract_entry, entry_type=int),
 }
 
 KNOT_VECTORS_CASTING = {
@@ -47,6 +46,7 @@ def read_knotvectors(list_of_lines):
         list: List of patch dicts
     """
 
+    patch_dimension = None
     patch_data = {}
     knots_data = {}
     patches = []
@@ -65,14 +65,17 @@ def read_knotvectors(list_of_lines):
             key = line_list.pop(0)
 
             # Begin reading in patch
-            if key == "BEGIN":
+            if key == "NURBS_DIMENSION":
+                patch_dimension = partial(_extract_entry, entry_type=int)(line_list)
+
+            elif key == "BEGIN":
                 patch_data["knot_vectors"] = []
 
             # End reading in patch
             elif key == "END":
                 # Check dimension
                 if (nurbs_dimension := len(patch_data["knot_vectors"])) != (
-                    nurbs_dimension_expected := patch_data.pop("NURBS_DIMENSION")
+                    nurbs_dimension_expected := patch_dimension
                 ):
                     raise ValueError(
                         f"Expected {nurbs_dimension_expected} knot vectors, got {nurbs_dimension}"

--- a/tests/fourcipp/legacy_io/test_knotvectors.py
+++ b/tests/fourcipp/legacy_io/test_knotvectors.py
@@ -91,6 +91,74 @@ def test_knotvectors_read_and_write(reference_knotvector_lines):
         assert reference_knotvector_lines[k].split() == lines[k].split()
 
 
+@pytest.fixture(name="reference_knotvector_lines_single_dimension")
+def fixture_reference_knotvector_lines_single_dimension():
+    """Reference lines."""
+    return [
+        "NURBS_DIMENSION                       2",
+        "BEGIN                                 NURBSPATCH",
+        "ID                                    1",
+        "NUMKNOTS                              7",
+        "DEGREE                                2",
+        "TYPE                                  Interpolated",
+        "0.0",
+        "0.0",
+        "0.0",
+        "0.5",
+        "1.0",
+        "1.0",
+        "1.0",
+        "",
+        "NUMKNOTS                              8",
+        "DEGREE                                2",
+        "TYPE                                  Interpolated",
+        "0.0",
+        "0.0",
+        "0.0",
+        "0.3333333333333333",
+        "0.6666666666666666",
+        "1.0",
+        "1.0",
+        "1.0",
+        "END                                   NURBSPATCH",
+        "BEGIN                                 NURBSPATCH",
+        "ID                                    2",
+        "NUMKNOTS                              7",
+        "DEGREE                                2",
+        "TYPE                                  Interpolated",
+        "0.0",
+        "0.0",
+        "0.0",
+        "0.5",
+        "1.0",
+        "1.0",
+        "1.0",
+        "NUMKNOTS                              8",
+        "DEGREE                                2",
+        "TYPE                                  Interpolated",
+        "0.0",
+        "0.0",
+        "0.0",
+        "0.3333333333333333",
+        "0.6666666666666666",
+        "1.0",
+        "1.0",
+        "1.0",
+        "END                                   NURBSPATCH",
+    ]
+
+
+def test_knotvectors_single_dimension_read_and_write(
+    fixture_reference_knotvector_lines_single_dimension, reference_knotvector_lines
+):
+    """Test read and write knotvectors."""
+    lines = write_knotvectors(
+        read_knotvectors(fixture_reference_knotvector_lines_single_dimension)
+    )
+    for k in range(len(reference_knotvector_lines)):
+        assert reference_knotvector_lines[k].split() == lines[k].split()
+
+
 def test_wrong_knotvectors_dimension_mismatch():
     """Test knotvectors with mismatching dimension."""
     invalid_knotvectors = [


### PR DESCRIPTION
Allow to read legacy NURBS input where `NURBS_DIMENSION` is not set for each patch.