### PR TITLE
Add converter to convert data to native Python data types

### DIFF
--- a/src/fourcipp/fourc_input.py
+++ b/src/fourcipp/fourc_input.py
@@ -67,6 +67,7 @@ class FourCInput:
     type_converter = CONVERTER
 
     def convert_to_native_types(self):
+        """Convert all sections to native Python types."""
         self._sections = self.type_converter(self._sections)
         self._legacy_sections = self.type_converter(self._legacy_sections)
 

--- a/src/fourcipp/fourc_input.py
+++ b/src/fourcipp/fourc_input.py
@@ -60,6 +60,9 @@ class FourCInput:
 
     known_sections = ALL_SECTIONS
 
+    # define a converter which converts data types to native Python types
+    type_converter = None
+
     def __init__(self, sections=None):
         """Initialise object.
 
@@ -128,6 +131,10 @@ class FourCInput:
             key (str): Section name
             value (dict): Section entry
         """
+
+        if self.type_converter:
+            value = self.type_converter(value)
+
         # Warn if complete section is overwritten
         if key in self.sections:
             logger.warning(f"Section {key} was overwritten.")
@@ -253,6 +260,9 @@ class FourCInput:
             other (dict, FourCInput): Sections to be updated
         """
         if isinstance(other, (dict, FourCInput)):
+            if isinstance(other, dict) and self.type_converter:
+                other = self.type_converter(other)
+
             for key, value in other.items():
                 self[key] = value
         else:
@@ -337,6 +347,9 @@ class FourCInput:
             validate (bool): Validate input data before dumping
         """
 
+        if self.type_converter:
+            self.type_converter(self.inlined)
+
         if validate:
             self.validate()
 
@@ -350,6 +363,9 @@ class FourCInput:
             sections_only (bool): Validate each section independently. Requiredness of the sections
                                   themselves is ignored.
         """
+        if self.type_converter:
+            self.type_converter(self.inlined)
+
         validation_schema = json_schema
 
         # Remove the requiredness of the sections

--- a/src/fourcipp/utils/converter.py
+++ b/src/fourcipp/utils/converter.py
@@ -21,6 +21,10 @@
 # THE SOFTWARE.
 """Converter to convert custom types to native Python types."""
 
+from __future__ import annotations
+
+from typing import Any, Callable
+
 import numpy as np
 
 
@@ -30,13 +34,30 @@ class Converter:
     def __init__(self):
         self._custom_converters = {}
 
-    def register_type(self, custom_type, converter_function):
-        """Register a custom type and its converter function."""
+    def register_type(
+        self, custom_type, converter_function: Callable[[Converter, Any], Any]
+    ):
+        """Register a custom type and its converter function.
+
+        The first argument of the converter_function is a converter object.
+        This allows you to pass self down to your converter function to
+        recursively call it and use custom types you already registered.
+        The second argument is the object to be converted.
+
+        Args:
+            custom_type (type): Custom class to register
+            converter_function (Callable): Converter function
+        """
         self._custom_converters[custom_type] = converter_function
         return self
 
     def register_types(self, types_dict):
-        """Register multiple custom types and their converter functions."""
+        """Register multiple custom types and their converter functions.
+
+        Args:
+            types_dict (dict): Dictionary with custom types as keys and
+            converter functions as values
+        """
         self._custom_converters.update(types_dict)
         return self
 
@@ -44,11 +65,21 @@ class Converter:
         """Register NumPy types and their converter functions."""
 
         def convert_ndarray(converter, obj):
-            """Convert a NumPy ndarray to a list."""
+            """Convert a NumPy ndarray to a list.
+
+            Args:
+                converter (Converter): Converter object
+                obj (np.ndarray): NumPy ndarray to convert
+            """
             return converter(obj.tolist())
 
         def convert_generic(converter, obj):
-            """Convert a NumPy generic type to a native Python type."""
+            """Convert a NumPy generic type to a native Python type.
+
+            Args:
+                converter (Converter): Converter object
+                obj (np.generic): NumPy generic type to convert
+            """
             return obj.item()
 
         self.register_type(np.generic, convert_generic)
@@ -56,7 +87,11 @@ class Converter:
         return self
 
     def __call__(self, obj):
-        """Convert the object to a native Python type."""
+        """Convert the object to a native Python type.
+
+        Args:
+            obj (Any): Object to convert
+        """
         # If no custom converters are present, no need to do a conversion
         if not self._custom_converters:
             return obj

--- a/src/fourcipp/utils/converter.py
+++ b/src/fourcipp/utils/converter.py
@@ -1,0 +1,86 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2025 FourCIPP Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+import numpy as np
+
+
+class Converter:
+    def __init__(self):
+        self._custom_converters = {}
+
+    def register_type(self, custom_type, converter_function):
+        self._custom_converters[custom_type] = converter_function
+        return self
+
+    def register_types(self, types_dict):
+        self._custom_converters.update(types_dict)
+        return self
+
+    def register_numpy_types(self):
+        def convert_ndarray(converter, obj):
+            return converter(obj.tolist())
+
+        def convert_generic(converter, obj):
+            return obj.item()
+
+        self.register_type(np.generic, convert_generic)
+        self.register_type(np.ndarray, convert_ndarray)
+        return self
+
+    def __call__(self, obj):
+        # If no custom converters are present, no need to do a conversion
+        if not self._custom_converters:
+            return obj
+
+        # Look if object is present in the custom converters
+        for custom_type in self._custom_converters:
+            if isinstance(obj, custom_type):
+                # First match will be used.
+                # Keep in mind for inheritance you have think about child classes!
+                # Make sure if you have parent and child classes registerd separately, to first register the child classes!
+                return self._custom_converters[custom_type](self, obj)
+
+        # Lets convert
+        match obj:
+            # Convert the nested types
+            case list():
+                return [self(entry) for entry in obj]
+            case set():
+                return (self(entry) for entry in obj)
+            case dict():
+                return {k: self(v) for k, v in obj.items()}
+
+            # Nothing to do here, since these are the accepted types
+            case int() | float() | bool() | str():
+                return obj
+
+            # Type was not registered and is not one of the standards one
+            case _:
+                raise TypeError(
+                    f"Object {obj} of type {type(obj)} can not be converted"
+                )
+
+    def __str__(self):
+        string = "Converter with custom object (objects will be converted from top to bottom):"
+        for k, v in self._custom_converters.items():
+            string += f"\n\t{k}\t: {v}"
+
+        return string

--- a/src/fourcipp/utils/converter.py
+++ b/src/fourcipp/utils/converter.py
@@ -19,26 +19,36 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+"""Converter to convert custom types to native Python types."""
+
 import numpy as np
 
 
 class Converter:
+    """Converter class to convert custom types to native Python types."""
+
     def __init__(self):
         self._custom_converters = {}
 
     def register_type(self, custom_type, converter_function):
+        """Register a custom type and its converter function."""
         self._custom_converters[custom_type] = converter_function
         return self
 
     def register_types(self, types_dict):
+        """Register multiple custom types and their converter functions."""
         self._custom_converters.update(types_dict)
         return self
 
     def register_numpy_types(self):
+        """Register NumPy types and their converter functions."""
+
         def convert_ndarray(converter, obj):
+            """Convert a NumPy ndarray to a list."""
             return converter(obj.tolist())
 
         def convert_generic(converter, obj):
+            """Convert a NumPy generic type to a native Python type."""
             return obj.item()
 
         self.register_type(np.generic, convert_generic)
@@ -46,6 +56,7 @@ class Converter:
         return self
 
     def __call__(self, obj):
+        """Convert the object to a native Python type."""
         # If no custom converters are present, no need to do a conversion
         if not self._custom_converters:
             return obj
@@ -55,7 +66,7 @@ class Converter:
             if isinstance(obj, custom_type):
                 # First match will be used.
                 # Keep in mind for inheritance you have think about child classes!
-                # Make sure if you have parent and child classes registerd separately, to first register the child classes!
+                # Make sure if you have parent and child classes registered separately, to first register the child classes!
                 return self._custom_converters[custom_type](self, obj)
 
         # Lets convert
@@ -79,6 +90,7 @@ class Converter:
                 )
 
     def __str__(self):
+        """String representation of the Converter class."""
         string = "Converter with custom object (objects will be converted from top to bottom):"
         for k, v in self._custom_converters.items():
             string += f"\n\t{k}\t: {v}"

--- a/src/fourcipp/utils/dict_utils.py
+++ b/src/fourcipp/utils/dict_utils.py
@@ -129,44 +129,6 @@ def compare_nested_dicts_or_lists(
     return True
 
 
-def convert_to_native_types(obj, custom_converter=None):
-    """Recursively convert objects to native python types. A custom converter
-    can be provided to convert custom objects.
-
-    Args:
-        obj (object): Object to convert.
-        custom_converter (callable): Callable to convert objects.
-            Returns a tuple of (converted_object, handled(bool))
-    """
-
-    if custom_converter is not None:
-        result, handled = custom_converter(obj)
-        if handled:
-            return result
-
-    if isinstance(obj, dict):
-        return {
-            key: convert_to_native_types(value, custom_converter=custom_converter)
-            for key, value in obj.items()
-        }
-    elif isinstance(obj, list):
-        return [
-            convert_to_native_types(item, custom_converter=custom_converter)
-            for item in obj
-        ]
-    elif isinstance(obj, set):
-        return {
-            convert_to_native_types(item, custom_converter=custom_converter)
-            for item in obj
-        }
-    elif isinstance(obj, np.ndarray):
-        return convert_to_native_types(obj.tolist(), custom_converter=custom_converter)
-    elif isinstance(obj, np.generic):
-        return obj.item()
-    else:
-        return obj
-
-
 def _get_dict(nested_dict, keys, optional=True):
     """Return dict entry within a nested dict by keys.
 

--- a/src/fourcipp/utils/dict_utils.py
+++ b/src/fourcipp/utils/dict_utils.py
@@ -129,6 +129,44 @@ def compare_nested_dicts_or_lists(
     return True
 
 
+def convert_to_native_types(obj, custom_converter=None):
+    """Recursively convert objects to native python types. A custom converter
+    can be provided to convert custom objects.
+
+    Args:
+        obj (object): Object to convert.
+        custom_converter (callable): Callable to convert objects.
+            Returns a tuple of (converted_object, handled(bool))
+    """
+
+    if custom_converter is not None:
+        result, handled = custom_converter(obj)
+        if handled:
+            return result
+
+    if isinstance(obj, dict):
+        return {
+            key: convert_to_native_types(value, custom_converter=custom_converter)
+            for key, value in obj.items()
+        }
+    elif isinstance(obj, list):
+        return [
+            convert_to_native_types(item, custom_converter=custom_converter)
+            for item in obj
+        ]
+    elif isinstance(obj, set):
+        return {
+            convert_to_native_types(item, custom_converter=custom_converter)
+            for item in obj
+        }
+    elif isinstance(obj, np.ndarray):
+        return convert_to_native_types(obj.tolist(), custom_converter=custom_converter)
+    elif isinstance(obj, np.generic):
+        return obj.item()
+    else:
+        return obj
+
+
 def _get_dict(nested_dict, keys, optional=True):
     """Return dict entry within a nested dict by keys.
 

--- a/tests/fourcipp/utils/test_converter.py
+++ b/tests/fourcipp/utils/test_converter.py
@@ -1,0 +1,99 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2025 FourCIPP Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""Test Converter class."""
+
+import numpy as np
+import pytest
+
+from fourcipp.utils.converter import Converter
+
+
+def test_basic_python_types():
+    """Test identity conversion for basic Python types."""
+    converter = Converter()
+    for value in [123, 12.5, "text", True]:
+        assert converter(value) == value
+
+
+def test_list_and_dict_conversion():
+    """Test identity conversion of nested lists and dictionaries."""
+    converter = Converter()
+    input_data = {"a": [1, 2, {"b": "text"}], "c": True}
+    assert converter(input_data) == input_data
+
+
+def test_nested_numpy_structures():
+    """Test nested structures with NumPy types."""
+    converter = Converter().register_numpy_types()
+
+    obj = {
+        "arr": np.array([1, 2, 3]),
+        "nested": {"scalar": np.int64(42), "float": np.float32(3.1)},
+    }
+
+    expected = {
+        "arr": [1, 2, 3],
+        "nested": {
+            "scalar": 42,
+            "float": pytest.approx(3.1),
+        },
+    }
+
+    result = converter(obj)
+    assert result["arr"] == expected["arr"]
+    assert result["nested"]["scalar"] == expected["nested"]["scalar"]
+    assert result["nested"]["float"] == expected["nested"]["float"]
+
+
+def test_register_custom_type():
+    """Test custom type registration and conversion."""
+
+    class Custom:
+        """Custom class for testing."""
+
+        def __init__(self, value):
+            self.value = value
+
+    def convert_custom(converter, obj):
+        """Custom conversion function for the Custom class."""
+        return {"custom_value": obj.value}
+
+    converter = Converter().register_type(Custom, convert_custom)
+
+    custom_obj = Custom("abc")
+    result = converter(custom_obj)
+    assert result == {"custom_value": "abc"}
+
+
+def test_not_convertible_type():
+    """Test conversion of a non-convertible type."""
+
+    # register a type to enable conversion
+    converter = Converter().register_numpy_types()
+
+    class UnknownType:
+        """Unknown type for testing."""
+
+        pass
+
+    with pytest.raises(TypeError, match=r"can not be converted"):
+        converter(UnknownType())


### PR DESCRIPTION
Closes #43 

This PR enables the conversion of all Numpy data types to native Python data types. Additionally, one can hand over arbitrary converters for data. I've tested it with all Numpy data types and also some MeshPy internal data types. Works as expected.

FYI @isteinbrecher 

@gilrrei What do you think? Currently I've added no tests because I am unsure on where to add them. Let me know what you think:)

(I'll also push a branch where I test it with MeshPy - I'll add a comment once that's done)