### PR TITLE
Improve validation error message during validation

### DIFF
--- a/src/fourcipp/utils/yaml_io.py
+++ b/src/fourcipp/utils/yaml_io.py
@@ -51,12 +51,11 @@ def load_yaml(path_to_yaml_file: Path) -> dict:
     return data
 
 
-def dump_yaml(data: dict, path_to_yaml_file: Path, sort_keys: bool = False) -> None:
-    """Dump yaml to file.
+def dict_to_yaml_string(data: dict, sort_keys=False) -> str:
+    """Dump dict as yaml.
 
     Args:
         data: Data to dump.
-        path_to_yaml_file: Yaml file path
         sort_keys: If true sort the sections by section name
     """
 
@@ -79,5 +78,17 @@ def dump_yaml(data: dict, path_to_yaml_file: Path, sort_keys: bool = False) -> N
         if tree.has_val(node_id):
             tree.set_val_style(node_id, ryml.NOTYPE)
 
-    with open(path_to_yaml_file, "w", encoding="utf-8") as f:
-        f.write(ryml.emit_yaml(tree))
+    return ryml.emit_yaml(tree)
+
+
+def dump_yaml(data: dict, path_to_yaml_file: Path, sort_keys: bool = False) -> None:
+    """Dump yaml to file.
+
+    Args:
+        data: Data to dump.
+        path_to_yaml_file: Yaml file path
+        sort_keys: If true sort the sections by section name
+    """
+    pathlib.Path(path_to_yaml_file).write_text(
+        dict_to_yaml_string(data, sort_keys), encoding="utf-8"
+    )

--- a/tests/fourcipp/test_fourc_input.py
+++ b/tests/fourcipp/test_fourc_input.py
@@ -29,7 +29,7 @@ import pytest
 
 from fourcipp import CONFIG
 from fourcipp.fourc_input import FourCInput, UnknownSectionException
-from fourcipp.utils.validation import FourCIPPValidationError
+from fourcipp.utils.validation import ValidationError
 
 
 @pytest.fixture(name="section_names")
@@ -457,7 +457,7 @@ def test_compare_failure_with_exception(fourc_input, fourc_input_2):
     [
         (
             FourCInput(sections={"TITLE": "some title"}),
-            pytest.raises(FourCIPPValidationError),
+            pytest.raises(ValidationError),
             False,
         ),
         (


### PR DESCRIPTION
This PR improves error messages during validation. Thanks @c-p-schmidt @dragos-ana for the idea.

Here an example:
```bash
Traceback (most recent call last):
  File "/home/ccxi/Desktop/fourcipp/src/fourcipp/utils/validation.py", line 84, in validate_using_json_schema
    validator.validate(data)
jsonschema_rs.ValidationError: Additional properties are not allowed ('wrong' was unexpected)

Failed validating "additionalProperties" in schema["properties"]["ALE DYNAMIC"]

On instance["ALE DYNAMIC"]:
    {"ALE_TYPE":"springs_material","LINEAR_SOLVER":2,"MAXTIME":0.5,"RESULTSEVERY":1,"TIMESTEP":0.25,"wrong":"parameter this is"}

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ccxi/Desktop/fourcipp/example.py", line 5, in <module>
    data.validate()
  File "/home/ccxi/Desktop/fourcipp/src/fourcipp/fourc_input.py", line 415, in validate
    validate_using_json_schema(self._sections, validation_schema)
  File "/home/ccxi/Desktop/fourcipp/src/fourcipp/utils/validation.py", line 87, in validate_using_json_schema
    raise ValidationError.from_errors(validator.iter_errors(data)) from exception
fourcipp.utils.validation.ValidationError: 
Validation failed, due to the following parameters:

- Parameter in ["ALE DYNAMIC"]
    
        ALE_TYPE: springs_material
        LINEAR_SOLVER: 2
        MAXTIME: 0.5
        RESULTSEVERY: 1
        TIMESTEP: 0.25
        wrong: parameter this is
        
  Error: Additional properties are not allowed ('wrong' was unexpected)

- Parameter in ["DESIGN POINT DIRICH CONDITIONS"][1]["ONOFF"][1]
    
        a
        
  Error: "a" is not of type "integer"

- Parameter in ["DISCRETISATION"]["NUMFLUIDDIS"]
    
        ups
        
  Error: "ups" is not of type "integer"

- Parameter in ["PROBLEM TYPE"]
    
        RANDSEED: -1
        RESTART: 0
        
  Error: "PROBLEMTYPE" is a required property

- Parameter in ["RESULT DESCRIPTION"][0]
    
        ALE:
          DIS: ale
          NODE: 3
          QUANTITY: dispx
          TOLERANCE: 1e-12
          VALUE: not a double
        
  Error: {"ALE":{"DIS":"ale","NODE":3,"QUANTITY":"dispx","TOLERANCE":1e-12,"VALUE":"not a double"}} is not valid under any of the schemas listed in the 'oneOf' keyword
```

Keep in mind that a more precise error message for `oneOf` is currently not possible, as we don't know which branch we were expected to validate (@sebproell, once more, this is a problem)

I did not include the legacy sections in the JSON validation as we only check if the entries are strings, not need to do a fancy check.