### PR TITLE
build: change the default dependency version behaviour

### DIFF
--- a/.github/workflows/check_code.yaml
+++ b/.github/workflows/check_code.yaml
@@ -29,7 +29,7 @@ jobs:
         shell: bash -el {0}
         run: |
           conda activate fourcipp
-          pip install -e .[dev]
+          pip install -e .[dev,safe]
           pip install pre-commit
       - name: Run code-checks
         shell: bash -el {0}

--- a/.github/workflows/run_testsuite.yaml
+++ b/.github/workflows/run_testsuite.yaml
@@ -37,7 +37,7 @@ jobs:
         shell: bash -el {0}
         run: |
           conda activate fourcipp
-          pip install -e .[dev]
+          pip install -e .[dev,safe]
       - name: Run pytest
         shell: bash -el {0}
         run: |
@@ -65,7 +65,7 @@ jobs:
         shell: bash -el {0}
         run: |
           conda activate fourcipp
-          pip install -e .[dev]
+          pip install -e .[dev,safe]
       - name: Run pytest using 4C_docker_main config
         run: |
           fourcipp-switch-profile 4C_docker_main

--- a/.github/workflows/update_4C_metadata_schema_file.yaml
+++ b/.github/workflows/update_4C_metadata_schema_file.yaml
@@ -44,7 +44,7 @@ jobs:
         shell: bash -el {0}
         run: |
           conda activate fourcipp
-          pip install -e .[dev]
+          pip install -e .[dev,safe]
           pip install pre-commit
       # files need to be specified because they are not yet staged and therefore pre-commit cannot find them
       # pre-commit hook is run twice to not fail if the first run fails (due to formatting files)

--- a/README.md
+++ b/README.md
@@ -20,19 +20,25 @@ For a quick and easy start an Anaconda/Miniconda environment is highly recommend
 execute the following steps:
 
 - Create a new Anaconda environment:
-```bash
-conda create -n fourcipp python=3.12
-```
+  ```bash
+  conda create -n fourcipp python=3.12
+  ```
 
 - Activate your newly created environment:
-```bash
-conda activate fourcipp
-```
+  ```bash
+  conda activate fourcipp
+  ```
 
-- Install all requirements with:
-```
-pip install .
-```
+- Install all requirements without fixed versions via:
+  ```
+  pip install .
+  ```
+  > Note: This is the default behavior. This allows to use fourcipp within other projects without version conflicts.
+
+- Install all requirements with fixed versions with:
+  ```
+  pip install .[safe]
+  ```
 
 Now you are up and running 🎉
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,10 @@ dynamic = ["dependencies"]
 fourcipp-switch-profile = "fourcipp.utils.configuration:change_profile_cli"
 
 [tool.setuptools.dynamic]
-dependencies = { file = ["requirements.txt"] }
+dependencies = { file = ["requirements.in"] } # No versions fixed
+optional-dependencies = { safe = { file = [
+    "requirements.txt",
+] } } # Every package version is fixed
 
 [tool.setuptools.package-data]
 "fourcipp.config" = ["*.json", "*.yaml"]


### PR DESCRIPTION
This PR changes the default behaviour of the dependency management:
- For the default installation, all package versions are disabled. This is good practice for libraries which fourcipp is. This allows for easy introduction of fourcipp in other packages, as we don't need a lot of packages. So fourcipp is lightweightish
- To avoid problems if they emerge, you can install fourcipp with a guaranteed fixed and working version via `.[safe]`
- The fixed versions are also used in the checks to avoid failing checks due to other packages

In general, this gives more flexibility to combine fourcipp with other packages!