### PR TITLE
fix quoting with ryml

### DIFF
--- a/src/fourcipp/utils/yaml_io.py
+++ b/src/fourcipp/utils/yaml_io.py
@@ -75,9 +75,6 @@ def dict_to_yaml_string(data: dict, sort_keys=False) -> str:
         if tree.has_key(node_id):
             tree.set_key_style(node_id, ryml.NOTYPE)
 
-        if tree.has_val(node_id):
-            tree.set_val_style(node_id, ryml.NOTYPE)
-
     return ryml.emit_yaml(tree)
 
 


### PR DESCRIPTION
This PR fixes quoting of values when dumping yaml.

Now the dict `{"a": [{"b": "2", "c": [2, {"A": "2", 2: True}]}]}` will be dumped to
```yaml
a:
  - b: "2"
    c:
      - 2
      - A: "2"
        2: true
```
This should fix #69 and I think we can revert #72

FYI: @davidrudlstorfer @c-p-schmidt @sebproell 