### PR TITLE
fix: read in and dump of inf strings

### DIFF
--- a/src/fourcipp/utils/yaml_io.py
+++ b/src/fourcipp/utils/yaml_io.py
@@ -23,6 +23,7 @@
 
 import json
 import pathlib
+import re
 
 import ryml
 
@@ -43,11 +44,15 @@ def load_yaml(path_to_yaml_file: Path) -> dict:
        Loaded data
     """
 
-    data = json.loads(
-        ryml.emit_json(
-            ryml.parse_in_arena(pathlib.Path(path_to_yaml_file).read_bytes())
-        )
+    json_str = ryml.emit_json(
+        ryml.parse_in_arena(pathlib.Path(path_to_yaml_file).read_bytes())
     )
+
+    # Convert `inf` to a string to avoid JSON parsing errors, see https://github.com/biojppm/rapidyaml/issues/312
+    json_str = re.sub(r":\s*inf\b", r': "inf"', json_str)
+
+    data = json.loads(json_str)
+
     return data
 
 


### PR DESCRIPTION
This fixes the currently failing fourcipp:

Currently we suspect that a bug in rapidyaml prevents us from reading in the metadata file as json and then dumping it into a python dict => https://github.com/biojppm/rapidyaml/issues/312#issuecomment-3048092744

While waiting for the upstream fix, this PR introduces a "temporary" fix.

@c-p-schmidt @dragos-ana this should fix the webviewer
@isteinbrecher @davidrudlstorfer this should fix beamme

FYI  @sebproell 