### PR TITLE
fix: add none to converter base types

### DIFF
--- a/src/fourcipp/utils/converter.py
+++ b/src/fourcipp/utils/converter.py
@@ -120,7 +120,7 @@ class Converter:
                 return {k: self(v) for k, v in obj.items()}
 
             # Nothing to do here, since these are the accepted types
-            case int() | float() | bool() | str():
+            case int() | float() | bool() | str() | None:
                 return obj
 
             # Type was not registered and is not one of the standards one


### PR DESCRIPTION
Necessary for https://github.com/beamme-py/beamme/pull/436