### PR TITLE
Add new function apply_user_defaults

### DIFF
--- a/src/fourcipp/fourc_input.py
+++ b/src/fourcipp/fourc_input.py
@@ -242,10 +242,10 @@ class FourCInput:
     def combine_sections(self, other: dict | FourCInput) -> None:
         """Combine input files together.
 
-        Note: Every sections can only be defined in self or in other.
+        Note: Every section can only be defined in self or in other.
 
         Args:
-            other: Sections to be combine
+            other: Sections to be combined
         """
         other_sections_names: Any = None
 
@@ -283,6 +283,48 @@ class FourCInput:
                 self[key] = value
         else:
             raise TypeError(f"Cannot overwrite sections from {type(other)}.")
+
+
+    def overwrite_values(self, other: dict | FourCInput) -> None:
+        """Combines two Inputs by overwriting current values by the other dict or FourCInput.
+
+        This function checks whether values exist in both objects and overwrites the current by the other.
+
+        Args:
+            other: dict/FourCInput to overwrite values from.
+        """
+
+        def _check_common_keys(dict1, dict2) -> dict:
+            """Recursive routine to check common keys/values between two dictionaries.
+            If values are different, dict2 is the significant one to overrule dict1."""
+
+            common_dict = {}
+            for dkey in dict1:
+                if dkey in dict2:
+                    if type(dict1[dkey]) == dict:
+                        common_dict[dkey] = _check_common_keys(dict1[dkey], dict2[dkey])
+                    else:
+                        common_dict[dkey] = dict2[dkey]
+                else:
+                    common_dict[dkey] = dict1[dkey]
+            for dkey in dict2:
+                if dkey in dict1:
+                    continue
+                common_dict[dkey] = dict2[dkey]
+            return common_dict
+
+        if isinstance(other, FourCInput):
+            other_sec = other.sections
+        elif isinstance(other, dict):
+            other_sec = other
+        else:
+            raise TypeError(f"Cannot overwrite sections from {type(other)}.")
+
+        common_dict = _check_common_keys(self.sections, other_sec)
+
+        self.overwrite_sections(common_dict)
+
+        return
 
     @property
     def sections(self) -> dict:

--- a/src/fourcipp/fourc_input.py
+++ b/src/fourcipp/fourc_input.py
@@ -284,9 +284,9 @@ class FourCInput:
         else:
             raise TypeError(f"Cannot overwrite sections from {type(other)}.")
 
-
     def overwrite_values(self, other: dict | FourCInput) -> None:
-        """Combines two Inputs by overwriting current values by the other dict or FourCInput.
+        """Combines two Inputs by overwriting current values by the other dict
+        or FourCInput.
 
         This function checks whether values exist in both objects and overwrites the current by the other.
 
@@ -294,9 +294,13 @@ class FourCInput:
             other: dict/FourCInput to overwrite values from.
         """
 
-        def _check_common_keys(dict1, dict2) -> dict:
-            """Recursive routine to check common keys/values between two dictionaries.
-            If values are different, dict2 is the significant one to overrule dict1."""
+        def _check_common_keys(dict1: dict, dict2: dict) -> dict:
+            """Recursive routine to check common keys/values between two
+            dictionaries.
+
+            If values are different, dict2 is the significant one to
+            overrule dict1.
+            """
 
             common_dict = {}
             for dkey in dict1:

--- a/src/fourcipp/fourc_input.py
+++ b/src/fourcipp/fourc_input.py
@@ -297,29 +297,36 @@ class FourCInput:
         default_input = FourCInput.from_4C_yaml(default_path, header_only=True)
         default_sections = default_input.sections
 
-        for sectionkey in default_sections:
-            if not isinstance(default_sections[sectionkey], dict):
-                continue
-            if sectionkey in self.sections:
+        for section_key in default_sections:
+            if not isinstance(default_sections[section_key], dict):
+                raise TypeError(f"Section {section_key} does not contain a dict.")
+            if section_key in self.sections:
                 # only check sections that are contained in the current object and in the default_sections
-                for parameter_key in default_sections[sectionkey]:
-                    if not isinstance(
-                        self[sectionkey][parameter_key],
-                        (int, float, str, bool, type(None)),
+                for parameter_key in default_sections[section_key]:
+                    if parameter_key not in self[section_key]:
+                        self[section_key][parameter_key] = default_sections[
+                            section_key
+                        ][parameter_key]
+                        logger.debug(
+                            "Setting user default value {default_sections[section_key]} to parameter {parameter_key} in section {section_key}"
+                        )
+                        continue
+                    if (
+                        not isinstance(
+                            self[section_key][parameter_key], (int, float, str, bool)
+                        )
+                        and self[section_key][parameter_key] is not None
                     ):
                         print(
                             "At this time, you should only use the default values for parameters in top level section!"
                         )
-                        continue
-                    if parameter_key not in self[sectionkey]:
-                        self[sectionkey][parameter_key] = default_sections[sectionkey][
-                            parameter_key
-                        ]
+                        raise TypeError(
+                            f"The value for parameter {parameter_key} in section {section_key} is not a primitive."
+                        )
             else:
-                # take the other_sec section if it is not in the current object
-                self[sectionkey] = default_sections[sectionkey]
-
-        return
+                # take the section content from default if it is not in the current object
+                self[section_key] = default_sections[section_key]
+                logger.debug("Adding user default section {section_key} to input file")
 
     @property
     def sections(self) -> dict:

--- a/tests/fourcipp/test_fourc_input.py
+++ b/tests/fourcipp/test_fourc_input.py
@@ -286,9 +286,6 @@ def test_apply_default(tmp_path):
     path_to_default = tmp_path / "default.4C.yaml"
     default_input = FourCInput({"PROBLEM TYPE": {"PROBLEMTYPE": "default problemtype"}})
     default_input["PROBLEM SIZE"] = {"DIM": 3}
-    default_input["MATERIALS"] = [
-        {"MAT": 1, "MAT_Struct_StVenantKirchhoff": {"YOUNG": 1, "NUE": 0.3}}
-    ]
     default_input.dump(path_to_default)
 
     # writing some entries to the current fourc_input
@@ -300,7 +297,7 @@ def test_apply_default(tmp_path):
 
     # Only in current input
     assert fourc_input["SOLVER 1"] == {"NAME": "current title"}
-    # Defined in default, overwritten by current input
+    # Defined in both default and current input -> do not overwrite with the default
     assert fourc_input["PROBLEM TYPE"] == {"PROBLEMTYPE": "current problemtype"}
     # Defined in default, not in current input -> should be taken
     assert fourc_input["PROBLEM SIZE"] == {"DIM": 3}

--- a/tests/fourcipp/test_fourc_input.py
+++ b/tests/fourcipp/test_fourc_input.py
@@ -250,29 +250,50 @@ def test_combine_sections_failure_doubled_data_dict(fourc_input):
 
 
 def test_overwrite_sections_new_section_dict(fourc_input):
-    """Test overwriting sections that does not exits."""
+    """Test overwriting sections that does not exist."""
     fourc_input.overwrite_sections({"TITLE": "new title"})
     fourc_input["TITLE"] == "new title"
 
 
 def test_overwrite_sections_existing_section_dict(fourc_input):
-    """Test overwriting sections that already exits."""
+    """Test overwriting sections that already exist."""
     fourc_input["TITLE"] = "new title"
     fourc_input.overwrite_sections({"TITLE": "super new title"})
     assert fourc_input["TITLE"] == "super new title"
 
 
 def test_overwrite_sections_new_section_input(fourc_input):
-    """Test overwriting sections that does not exits."""
+    """Test overwriting sections that does not exist."""
     fourc_input.overwrite_sections(FourCInput({"TITLE": "new title"}))
     fourc_input["TITLE"] == "new title"
 
 
 def test_overwrite_sections_existing_section_input(fourc_input):
-    """Test overwriting sections that already exits."""
+    """Test overwriting sections that already exist."""
     fourc_input["TITLE"] = "new title"
     fourc_input.overwrite_sections(FourCInput({"TITLE": "super new title"}))
     assert fourc_input["TITLE"] == "super new title"
+
+
+def test_overwrite_values_new_section_dict(fourc_input):
+    """Test overwriting a complete section that does not exist."""
+    fourc_input.overwrite_values({"TITLE": "new title"})
+    fourc_input["TITLE"] == "new title"
+
+
+def test_overwrite_values_existing_section_dict(fourc_input):
+    """Test overwriting one value in an existing section."""
+    fourc_input["PROBLEM TYPE"] = {"PROBLEMTYPE": "old problemtype"}
+    fourc_input.overwrite_values({"PROBLEM TYPE": {"PROBLEMTYPE": "new problemtype"}})
+    fourc_input["PROBLEM TYPE"] == {"PROBLEMTYPE": "new problemtype"}
+
+
+def test_add_values_existing_section_dict(fourc_input):
+    """Test add a value in an existing section."""
+    fourc_input["PROBLEM TYPE"] = {"PROBLEMTYPE": "old problemtype"}
+    fourc_input.overwrite_values({"PROBLEM TYPE": {"RESTART": 1}})
+    fourc_input["PROBLEM TYPE"]["PROBLEMTYPE"] == "old problemtype"
+    fourc_input["PROBLEM TYPE"]["RESTART"] == 1
 
 
 def test_add(fourc_input, fourc_input_2, fourc_input_combined):

--- a/tests/fourcipp/test_fourc_input.py
+++ b/tests/fourcipp/test_fourc_input.py
@@ -252,7 +252,7 @@ def test_combine_sections_failure_doubled_data_dict(fourc_input):
 def test_overwrite_sections_new_section_dict(fourc_input):
     """Test overwriting sections that does not exist."""
     fourc_input.overwrite_sections({"TITLE": "new title"})
-    fourc_input["TITLE"] == "new title"
+    assert fourc_input["TITLE"] == "new title"
 
 
 def test_overwrite_sections_existing_section_dict(fourc_input):
@@ -265,7 +265,7 @@ def test_overwrite_sections_existing_section_dict(fourc_input):
 def test_overwrite_sections_new_section_input(fourc_input):
     """Test overwriting sections that does not exist."""
     fourc_input.overwrite_sections(FourCInput({"TITLE": "new title"}))
-    fourc_input["TITLE"] == "new title"
+    assert fourc_input["TITLE"] == "new title"
 
 
 def test_overwrite_sections_existing_section_input(fourc_input):
@@ -278,22 +278,22 @@ def test_overwrite_sections_existing_section_input(fourc_input):
 def test_overwrite_values_new_section_dict(fourc_input):
     """Test overwriting a complete section that does not exist."""
     fourc_input.overwrite_values({"TITLE": "new title"})
-    fourc_input["TITLE"] == "new title"
+    assert fourc_input["TITLE"] == "new title"
 
 
 def test_overwrite_values_existing_section_dict(fourc_input):
     """Test overwriting one value in an existing section."""
     fourc_input["PROBLEM TYPE"] = {"PROBLEMTYPE": "old problemtype"}
     fourc_input.overwrite_values({"PROBLEM TYPE": {"PROBLEMTYPE": "new problemtype"}})
-    fourc_input["PROBLEM TYPE"] == {"PROBLEMTYPE": "new problemtype"}
+    assert fourc_input["PROBLEM TYPE"] == {"PROBLEMTYPE": "new problemtype"}
 
 
 def test_add_values_existing_section_dict(fourc_input):
     """Test add a value in an existing section."""
     fourc_input["PROBLEM TYPE"] = {"PROBLEMTYPE": "old problemtype"}
     fourc_input.overwrite_values({"PROBLEM TYPE": {"RESTART": 1}})
-    fourc_input["PROBLEM TYPE"]["PROBLEMTYPE"] == "old problemtype"
-    fourc_input["PROBLEM TYPE"]["RESTART"] == 1
+    assert fourc_input["PROBLEM TYPE"]["PROBLEMTYPE"] == "old problemtype"
+    assert fourc_input["PROBLEM TYPE"]["RESTART"] == 1
 
 
 def test_add(fourc_input, fourc_input_2, fourc_input_combined):

--- a/tests/fourcipp/test_fourc_input.py
+++ b/tests/fourcipp/test_fourc_input.py
@@ -275,25 +275,37 @@ def test_overwrite_sections_existing_section_input(fourc_input):
     assert fourc_input["TITLE"] == "super new title"
 
 
-def test_overwrite_values_new_section_dict(fourc_input):
-    """Test overwriting a complete section that does not exist."""
-    fourc_input.overwrite_values({"TITLE": "new title"})
-    assert fourc_input["TITLE"] == "new title"
+def test_apply_default(tmp_path):
+    """Test using a default file.
 
+    4C default file with a section that is not in the input file and one
+    that is. A section containing a list should not be added.
+    """
 
-def test_overwrite_values_existing_section_dict(fourc_input):
-    """Test overwriting one value in an existing section."""
-    fourc_input["PROBLEM TYPE"] = {"PROBLEMTYPE": "old problemtype"}
-    fourc_input.overwrite_values({"PROBLEM TYPE": {"PROBLEMTYPE": "new problemtype"}})
-    assert fourc_input["PROBLEM TYPE"] == {"PROBLEMTYPE": "new problemtype"}
+    # Creating the default file
+    path_to_default = tmp_path / "default.4C.yaml"
+    default_input = FourCInput({"PROBLEM TYPE": {"PROBLEMTYPE": "default problemtype"}})
+    default_input["PROBLEM SIZE"] = {"DIM": 3}
+    default_input["MATERIALS"] = [
+        {"MAT": 1, "MAT_Struct_StVenantKirchhoff": {"YOUNG": 1, "NUE": 0.3}}
+    ]
+    default_input.dump(path_to_default)
 
+    # writing some entries to the current fourc_input
+    fourc_input = FourCInput({"SOLVER 1": {"NAME": "current title"}})
+    fourc_input["PROBLEM TYPE"] = {"PROBLEMTYPE": "current problemtype"}
 
-def test_add_values_existing_section_dict(fourc_input):
-    """Test add a value in an existing section."""
-    fourc_input["PROBLEM TYPE"] = {"PROBLEMTYPE": "old problemtype"}
-    fourc_input.overwrite_values({"PROBLEM TYPE": {"RESTART": 1}})
-    assert fourc_input["PROBLEM TYPE"]["PROBLEMTYPE"] == "old problemtype"
-    assert fourc_input["PROBLEM TYPE"]["RESTART"] == 1
+    # Applying the defaults
+    fourc_input.apply_user_defaults(path_to_default)
+
+    # Only in current input
+    assert fourc_input["SOLVER 1"] == {"NAME": "current title"}
+    # Defined in default, overwritten by current input
+    assert fourc_input["PROBLEM TYPE"] == {"PROBLEMTYPE": "current problemtype"}
+    # Defined in default, not in current input -> should be taken
+    assert fourc_input["PROBLEM SIZE"] == {"DIM": 3}
+    # should not be taken even though it is in the default file, because it is a list
+    assert not "MATERIALS" in fourc_input
 
 
 def test_add(fourc_input, fourc_input_2, fourc_input_combined):


### PR DESCRIPTION
## Description

The new function takes a a path to a FourCInput, which serves as a defaults file, which contains some values that are applied as long as no other values are contained in the current  FourCInput  

At this time, the function only considers simple sections, which contain key-values pairs with values being primitives, no lists or nested dicts.