### PR TITLE
Fix fourcipp

### DIFF
--- a/src/fourcipp/__init__.py
+++ b/src/fourcipp/__init__.py
@@ -32,9 +32,9 @@ logger.disable("fourcipp")
 CONFIG = load_config()
 
 DESCRIPTION_SECTION = CONFIG["4C_metadata"]["metadata"]["description_section_name"]
-SECTIONS = [section["name"] for section in CONFIG["4C_metadata"]["sections"]] + [
-    DESCRIPTION_SECTION
-]
+SECTIONS = [
+    section["name"] for section in CONFIG["4C_metadata"]["sections"]["specs"]
+] + [DESCRIPTION_SECTION]
 LEGACY_SECTIONS = list(CONFIG["4C_metadata"]["legacy_string_sections"])
 ALL_SECTIONS = sorted(SECTIONS + LEGACY_SECTIONS)
 

--- a/src/fourcipp/utils/yaml_io.py
+++ b/src/fourcipp/utils/yaml_io.py
@@ -49,7 +49,12 @@ def load_yaml(path_to_yaml_file: Path) -> dict:
     )
 
     # Convert `inf` to a string to avoid JSON parsing errors, see https://github.com/biojppm/rapidyaml/issues/312
-    json_str = re.sub(r":\s*inf\b", r': "inf"', json_str)
+    json_str = re.sub(r":\s*(-?)inf\b", r': "\1inf"', json_str)
+
+    # Convert floats that are missing digits on either side of the decimal point
+    # so .5 to 0.5 and 5. to 5.0
+    json_str = re.sub(r":\s*(-?)\.([0-9]+)", r": \g<1>0.\2", json_str)
+    json_str = re.sub(r":\s*(-?)([0-9]+)\.(\D)", r": \1\2.0\3", json_str)
 
     data = json.loads(json_str)
 

--- a/tests/fourcipp/test_fourc_input.py
+++ b/tests/fourcipp/test_fourc_input.py
@@ -41,16 +41,16 @@ from ..fourcipp.legacy_io.test_element import (  # noqa: TID252
 @pytest.fixture(name="section_names")
 def fixture_section_names():
     """Section names."""
-    section_name_1 = CONFIG["4C_metadata"]["sections"][0]["name"]
-    section_name_2 = CONFIG["4C_metadata"]["sections"][1]["name"]
+    section_name_1 = CONFIG["4C_metadata"]["sections"]["specs"][0]["name"]
+    section_name_2 = CONFIG["4C_metadata"]["sections"]["specs"][1]["name"]
     return section_name_1, section_name_2
 
 
 @pytest.fixture(name="section_names_2")
 def fixture_section_names_2():
     """More section names."""
-    section_name_3 = CONFIG["4C_metadata"]["sections"][2]["name"]
-    section_name_4 = CONFIG["4C_metadata"]["sections"][3]["name"]
+    section_name_3 = CONFIG["4C_metadata"]["sections"]["specs"][2]["name"]
+    section_name_4 = CONFIG["4C_metadata"]["sections"]["specs"][3]["name"]
     return section_name_3, section_name_4
 
 


### PR DESCRIPTION
- Extract the section names from the sections all of
- Fixes trailing zero issue with floats, thanks @sebproell 

This change broke all the projects that build upon fourcipp, from beamme, fourcwebviewer, QUEENS etc. This once more highlights the need for versioning of the 4C input such as that we can avoid these problems in the future 4C-multiphysics/4C#74
