### PR TITLE
build: change git precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,11 +29,9 @@ repos:
         name: Check valid YAML syntax
       - id: end-of-file-fixer
         name: Check for newline at end of file
-        exclude: '^LICENSE$'
+        exclude: "^LICENSE$"
       - id: debug-statements
         name: Check for debugger imports
-      - id: no-commit-to-branch
-        name: Check to not commit to main
       - id: trailing-whitespace
         name: Check for trailing whitespaces
   - repo: https://github.com/PyCQA/bandit
@@ -72,7 +70,7 @@ repos:
           - --license-filepath
           - LICENSE
           - --comment-style
-          - '#'
+          - "#"
           - --no-extra-eol
   - repo: https://github.com/asmeurer/removestar
     rev: "1.5.2"


### PR DESCRIPTION
Remove the check if one is committed to main. It's a personal choice how to name the branches, so let's remove this.