### PR TITLE
fix: workflow for publishing

### DIFF
--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -7,64 +7,29 @@ on:
       - "v[0-9]*.[0-9]*.[0-9]*"
 
 jobs:
-  build_wheels:
-    name: Build wheels for ${{ matrix.os }}
-    runs-on: ${{ matrix.runs-on }}
-    strategy:
-      matrix:
-        include:
-          - os: linux-intel
-            runs-on: ubuntu-latest
-          - os: linux-arm
-            runs-on: ubuntu-24.04-arm
-          - os: windows-intel
-            runs-on: windows-latest
-          - os: windows-arm
-            runs-on: windows-11-arm
-          - os: macos-intel
-            runs-on: macos-13
-          - os: macos-arm
-            runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v3.1.4
-        with:
-          output-dir: dist
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-          path: ./dist/*.whl
-
-  build_sdist:
-    name: Build source distribution
+  build_dist:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
-      - name: Build sdist
-        run: pipx run build --sdist
+      - name: Build sdist and wheel
+        run: pipx run build
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-sdist
-          path: dist/*.tar.gz
+          name: dist
+          path: dist/*
 
   upload_pypi:
-    needs: [build_wheels, build_sdist]
+    needs: build_dist
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
       id-token: write
-
     steps:
       - uses: actions/download-artifact@v5
         with:
-          pattern: cibw-*
+          name: dist
           path: dist
-          merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tag_version.yaml
+++ b/.github/workflows/tag_version.yaml
@@ -1,12 +1,15 @@
 name: Auto Tag Versioning
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Testsuite"]
+    types:
+      - completed
 
 jobs:
   tag:
+    # only tag versions after a new commit to main and after successful testing (not after scheduled/cron testing)
+    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
So this PR should fix the issue(s) of #94 

- we now only add a version to a fourcipp commit if the associated testing succeeded (tested this on my own fork and the if conditions worked)
- downside - we now only have versions to successfull commits, so if the testsuite fails for a metadata update we have no version
- I did not know that for pure python packages you are "not allowed" to use cibuildwheel, now I use the other approach which worked locally and produced a universal wheel

