### PR TITLE
Add option for custom dict ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ input_4C["PROBLEM SIZE"]["NODES"] = 10_000_000
 removed_section = input_4C.pop("PROBLEM SIZE")
 
 # Dump to file
-input_4C.dump(input_file_path, sort_sections=True, validate=True)
+input_4C.dump(input_file_path, validate=True)
 ```
 <!--example, do not remove this comment-->
 

--- a/src/fourcipp/utils/configuration.py
+++ b/src/fourcipp/utils/configuration.py
@@ -45,7 +45,7 @@ class Sections:
         """
         self.legacy_sections: list[str] = legacy_sections
         self.typed_sections: list[str] = typed_sections
-        self.all_sections: list[str] = legacy_sections + typed_sections
+        self.all_sections: list[str] = typed_sections + legacy_sections
 
     @classmethod
     def from_metadata(cls, fourc_metadata: dict) -> Sections:
@@ -58,9 +58,10 @@ class Sections:
             Sections: sections object
         """
         description_section = fourc_metadata["metadata"]["description_section_name"]
-        sections = [
+        sections = [description_section] + [
             section["name"] for section in fourc_metadata["sections"]["specs"]
-        ] + [description_section]
+        ]
+
         legacy_sections = list(fourc_metadata["legacy_string_sections"])
 
         return cls(legacy_sections, sections)

--- a/src/fourcipp/utils/dict_utils.py
+++ b/src/fourcipp/utils/dict_utils.py
@@ -373,3 +373,35 @@ def rename_parameter(
 
     for entry, last_key in _split_off_last_key(nested_dict, keys):
         entry[new_name] = entry.pop(last_key)
+
+
+def sort_by_key_order(data: dict, key_order: list[str]) -> dict:
+    """Sort a dictionary by a specific key order.
+
+    Args:
+        data: Dictionary to sort.
+        key_order: List of keys in the desired order.
+
+    Returns:
+        Sorted dictionary.
+    """
+    if set(key_order) != set(data.keys()):
+        raise ValueError("'key_order' must include all keys in the dictionary!")
+
+    return {key: data[key] for key in key_order if key in data}
+
+
+def sort_alphabetically(
+    data: dict,
+) -> dict:
+    """Sort a dictionary alphabetically.
+
+    Args:
+        data: Dictionary to sort.
+
+    Returns:
+        Sorted dictionary.
+    """
+    return sort_by_key_order(
+        data, sorted(data.keys(), key=lambda s: (s.lower(), 0 if s.islower() else 1))
+    )

--- a/src/fourcipp/utils/yaml_io.py
+++ b/src/fourcipp/utils/yaml_io.py
@@ -24,6 +24,7 @@
 import json
 import pathlib
 import re
+from typing import Callable
 
 import ryml
 
@@ -61,17 +62,21 @@ def load_yaml(path_to_yaml_file: Path) -> dict:
     return data
 
 
-def dict_to_yaml_string(data: dict, sort_keys: bool = False) -> str:
+def dict_to_yaml_string(
+    data: dict, sort_function: Callable[[dict], dict] | None = None
+) -> str:
     """Dump dict as yaml.
 
     Args:
         data: Data to dump.
-        sort_keys: If true sort the sections by section name
+        sort_function: Function to sort the data.
+
+    Returns:
+        YAML string representation of the data
     """
 
-    # Sort keys
-    if sort_keys:
-        data = {key: data[key] for key in sorted(data.keys())}
+    if sort_function is not None:
+        data = sort_function(data)
 
     # Convert dictionary into a ryml tree
     tree = ryml.parse_in_arena(bytearray(json.dumps(data).encode("utf8")))
@@ -88,14 +93,19 @@ def dict_to_yaml_string(data: dict, sort_keys: bool = False) -> str:
     return ryml.emit_yaml(tree)
 
 
-def dump_yaml(data: dict, path_to_yaml_file: Path, sort_keys: bool = False) -> None:
+def dump_yaml(
+    data: dict,
+    path_to_yaml_file: Path,
+    sort_function: Callable[[dict], dict] | None = None,
+) -> None:
     """Dump yaml to file.
 
     Args:
         data: Data to dump.
         path_to_yaml_file: Yaml file path
-        sort_keys: If true sort the sections by section name
+        sort_function: Function to sort the data.
     """
     pathlib.Path(path_to_yaml_file).write_text(
-        dict_to_yaml_string(data, sort_keys), encoding="utf-8"
+        dict_to_yaml_string(data, sort_function),
+        encoding="utf-8",
     )

--- a/tests/fourcipp/utils/test_dict_utils.py
+++ b/tests/fourcipp/utils/test_dict_utils.py
@@ -34,6 +34,8 @@ from fourcipp.utils.dict_utils import (
     remove,
     rename_parameter,
     replace_value,
+    sort_alphabetically,
+    sort_by_key_order,
 )
 
 
@@ -664,3 +666,30 @@ def test_get_dict_optional(nested_input_dict):
         result = entry
     # assert if nothing changed
     assert result == "some value"
+
+
+def test_sort_by_key_order_basic():
+    """Test sorting by key order."""
+
+    data = {"b": 2, "a": 1, "c": 3}
+
+    assert sort_by_key_order(data, ["a", "b", "c"]) == {"a": 1, "b": 2, "c": 3}
+
+
+def test_sort_by_key_order_error_mismatched_keys():
+    """Test sorting by key order with mismatched keys."""
+
+    data = {"b": 2, "a": 1, "c": 3}
+
+    with pytest.raises(
+        ValueError, match="'key_order' must include all keys in the dictionary!"
+    ):
+        sort_by_key_order(data, ["a", "b"])
+
+
+def test_sort_alphabetically():
+    """Test alphabetical sorting."""
+
+    data = {"A": 1, "b": 2, "a": 0, "B": 3, "c": 4, "C": 5}
+
+    assert sort_alphabetically(data) == {"a": 0, "A": 1, "b": 2, "B": 3, "c": 4, "C": 5}

--- a/tests/fourcipp/utils/test_yaml_io.py
+++ b/tests/fourcipp/utils/test_yaml_io.py
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 """Test yaml io utils."""
 
+from fourcipp.utils.dict_utils import sort_alphabetically
 from fourcipp.utils.yaml_io import dump_yaml, load_yaml
 
 
@@ -33,10 +34,12 @@ def test_dump_not_sorted(tmp_path):
     assert reloaded_data == data
 
 
-def test_dump_sorted(tmp_path):
+def test_dump_sorted_alphabetically(tmp_path):
     """Test if key order is sorted."""
     data = {"c": 1, "b": 2, "a": 3}
     sorted_file_path = tmp_path / "sorted.yaml"
-    dump_yaml(data, path_to_yaml_file=sorted_file_path, sort_keys=True)
+    dump_yaml(
+        data, path_to_yaml_file=sorted_file_path, sort_function=sort_alphabetically
+    )
     reloaded_data = load_yaml(sorted_file_path)
     assert list(reloaded_data.keys()) == sorted(data.keys())


### PR DESCRIPTION
@gilrrei I know that we already discussed this offline. This would be a pretty minimal invasive option to give all FourCIPP users the option to custom sort the dict before dumping.

This also moves the sort logic out of our yaml logic. It looks like a lot of code because of the unit tests and docu but actually its just 5 lines of new code.

Let me know if this collides with other plans or if this would be ok to merge.

Closes #81 