### PR TITLE
Add fourcipp yaml style

### DIFF
--- a/src/fourcipp/fourc_input.py
+++ b/src/fourcipp/fourc_input.py
@@ -496,6 +496,7 @@ class FourCInput:
         validate_sections_only: bool = False,
         convert_to_native_types: bool = True,
         sort_function: Callable[[dict], dict] | None = _sort_by_section_names,
+        use_fourcipp_yaml_style: bool = True,
     ) -> None:
         """Dump object to yaml.
 
@@ -506,6 +507,7 @@ class FourCInput:
                 Requiredness of the sections themselves is ignored.
             convert_to_native_types: Convert all sections to native Python types
             sort_function: Function to sort the sections.
+            use_fourcipp_yaml_style: If FourCIPP yaml style is to be used
         """
 
         if validate or validate_sections_only:
@@ -520,7 +522,7 @@ class FourCInput:
         if convert_to_native_types:
             self.convert_to_native_types()
 
-        dump_yaml(self.inlined, input_file_path, sort_function)
+        dump_yaml(self.inlined, input_file_path, sort_function, use_fourcipp_yaml_style)
 
     def validate(
         self,

--- a/src/fourcipp/utils/yaml_io.py
+++ b/src/fourcipp/utils/yaml_io.py
@@ -63,13 +63,17 @@ def load_yaml(path_to_yaml_file: Path) -> dict:
 
 
 def dict_to_yaml_string(
-    data: dict, sort_function: Callable[[dict], dict] | None = None
+    data: dict,
+    sort_function: Callable[[dict], dict] | None = None,
+    use_fourcipp_yaml_style: bool = True,
 ) -> str:
     """Dump dict as yaml.
 
+    The FourCIPP yaml style sets flow
     Args:
         data: Data to dump.
         sort_function: Function to sort the data.
+        use_fourcipp_yaml_style: If FourCIPP yaml style is to be used
 
     Returns:
         YAML string representation of the data
@@ -81,11 +85,60 @@ def dict_to_yaml_string(
     # Convert dictionary into a ryml tree
     tree = ryml.parse_in_arena(bytearray(json.dumps(data).encode("utf8")))
 
-    # remove all style bits to enable a YAML style output
+    def check_is_vector(tree: ryml.Tree, node_id: int) -> bool:
+        """Check if sequence is of ints, floats or sequence there of.
+
+        In 4C metadata terms, list of strings, bools, etc. could also be vectors.
+        For the sake of simplicity these are omitted.
+
+        Args:
+            tree (ryml.Tree): Tree to check
+            node_id (int): Node id
+
+        Returns:
+            returns if entry is a vector
+        """
+
+        for sub_node, _ in ryml.walk(tree, node_id):
+            # Ignore the root node
+            if sub_node == node_id:
+                continue
+
+            # If sequence contains a dict
+            if tree.is_map(sub_node):
+                return False
+
+            # If sequence contains a sequence
+            elif tree.is_seq(sub_node):
+                if not check_is_vector(tree, sub_node):
+                    return False
+
+            # Else it's a value
+            else:
+                val = tree.val(sub_node).tobytes().decode("ascii")
+                is_not_numeric = (
+                    tree.is_val_quoted(sub_node)  # string
+                    or tree.val_is_null(sub_node)  # null
+                    or val == "true"  # bool
+                    or val == "false"  # bool
+                )
+                if is_not_numeric:
+                    return False
+
+        return True
+
+    # Change style bits to avoid JSON output and format vectors correctly
     # see https://github.com/biojppm/rapidyaml/issues/520
-    for node_id, _ in ryml.walk(tree):
-        if tree.is_map(node_id) or tree.is_seq(node_id):
+    for node_id, depth in ryml.walk(tree):
+        if tree.is_map(node_id):
             tree.set_container_style(node_id, ryml.NOTYPE)
+        elif tree.is_seq(node_id):
+            if (
+                not use_fourcipp_yaml_style  # do not do special formatting
+                or depth == 1  # is a section
+                or not check_is_vector(tree, node_id)  # is not a vector
+            ):
+                tree.set_container_style(node_id, ryml.NOTYPE)
 
         if tree.has_key(node_id):
             tree.set_key_style(node_id, ryml.NOTYPE)
@@ -97,15 +150,17 @@ def dump_yaml(
     data: dict,
     path_to_yaml_file: Path,
     sort_function: Callable[[dict], dict] | None = None,
+    use_fourcipp_yaml_style: bool = True,
 ) -> None:
     """Dump yaml to file.
 
     Args:
         data: Data to dump.
         path_to_yaml_file: Yaml file path
-        sort_function: Function to sort the data.
+        sort_function: Function to sort the data
+        use_fourcipp_yaml_style: If FourCIPP yaml style is to be used
     """
     pathlib.Path(path_to_yaml_file).write_text(
-        dict_to_yaml_string(data, sort_function),
+        dict_to_yaml_string(data, sort_function, use_fourcipp_yaml_style),
         encoding="utf-8",
     )

--- a/tests/fourcipp/utils/test_yaml_io.py
+++ b/tests/fourcipp/utils/test_yaml_io.py
@@ -21,8 +21,10 @@
 # THE SOFTWARE.
 """Test yaml io utils."""
 
+import pytest
+
 from fourcipp.utils.dict_utils import sort_alphabetically
-from fourcipp.utils.yaml_io import dump_yaml, load_yaml
+from fourcipp.utils.yaml_io import dict_to_yaml_string, dump_yaml, load_yaml
 
 
 def test_dump_not_sorted(tmp_path):
@@ -43,3 +45,82 @@ def test_dump_sorted_alphabetically(tmp_path):
     )
     reloaded_data = load_yaml(sorted_file_path)
     assert list(reloaded_data.keys()) == sorted(data.keys())
+
+
+@pytest.mark.parametrize(
+    "use_fourcipp_yaml_style, expected",
+    [
+        (
+            False,
+            """SECTION:
+  - vector:
+      - 1.23
+      - 2
+      - 3
+    nested_vector:
+      - - 1
+        - 2.0
+        - 3
+      - - 4.5
+        - 5
+        - 2.333
+  - list_with_bool:
+      - 1
+      - true
+      - 3
+    list_with_null:
+      - 1
+      - null
+      - 4
+  - list_with_string:
+      - 1
+      - "abc"
+      - 5
+    nested_list_with_string:
+      - - 1
+        - 2.1
+      - - 2
+        - "def"
+""",
+        ),
+        (
+            True,
+            """SECTION:
+  - vector: [1.23,2,3]
+    nested_vector: [[1,2.0,3],[4.5,5,2.333]]
+  - list_with_bool:
+      - 1
+      - true
+      - 3
+    list_with_null:
+      - 1
+      - null
+      - 4
+  - list_with_string:
+      - 1
+      - "abc"
+      - 5
+    nested_list_with_string:
+      - [1,2.1]
+      - - 2
+        - "def"
+""",
+        ),
+    ],
+)
+def test_yaml_style(use_fourcipp_yaml_style, expected):
+    """Test yaml output style."""
+    data = {
+        "SECTION": [
+            {"vector": [1.23, 2, 3], "nested_vector": [[1, 2.0, 3], [4.5, 5, 2.333]]},
+            {"list_with_bool": [1, True, 3], "list_with_null": [1, None, 4]},
+            {
+                "list_with_string": [1, "abc", 5],
+                "nested_list_with_string": [[1, 2.1], [2, "def"]],
+            },
+        ]
+    }
+    assert (
+        dict_to_yaml_string(data, use_fourcipp_yaml_style=use_fourcipp_yaml_style)
+        == expected
+    )


### PR DESCRIPTION
This PR adds a fourcipp yaml style where sequences (of sequences) of ints/floats will be written as `[[1,2],[3,4]]`. Also adds a cli to format your files.

Follows @davidrudlstorfer nice work in #97

Currently, the default output is:
```yaml
SECTION:
  - vector:
      - 1
      - 2
      - 3
    nested_vector:
      - - 1
        - 2
        - 3
      - - 4
        - 5
        - 6
  - list_with_bool:
      - 1
      - true
      - 3
    list_with_null:
      - 1
      - null
      - 4
  - list_with_string:
      - 1
      - "abc"
      - 5
    nested_list_with_string:
      - - 1
        - 2
      - - 2
        - "def"
```
now it's a bit more compact
```yaml
SECTION:
  - vector: [1,2,3]
    nested_vector: [[1,2,3],[4,5,6]]
  - list_with_bool:
      - 1
      - true
      - 3
    list_with_null:
      - 1
      - null
      - 4
  - list_with_string:
      - 1
      - "abc"
      - 5
    nested_list_with_string:
      - [1,2]
      - - 2
        - "def"'''
```
 