### PR TITLE
Rename _sort_by_section_names function

### DIFF
--- a/src/fourcipp/fourc_input.py
+++ b/src/fourcipp/fourc_input.py
@@ -69,7 +69,7 @@ def is_section_known(section_name: str, known_section_names: list[str]) -> bool:
     return section_name in known_section_names or section_name.startswith("FUNCT")
 
 
-def _sort_by_section_names(data: dict) -> dict:
+def sort_by_section_names(data: dict) -> dict:
     """Sort a dictionary by its 4C sections.
 
     This sorts the dictionary in the following style:
@@ -495,7 +495,7 @@ class FourCInput:
         validate: bool = False,
         validate_sections_only: bool = False,
         convert_to_native_types: bool = True,
-        sort_function: Callable[[dict], dict] | None = _sort_by_section_names,
+        sort_function: Callable[[dict], dict] | None = sort_by_section_names,
         use_fourcipp_yaml_style: bool = True,
     ) -> None:
         """Dump object to yaml.

--- a/tests/fourcipp/test_fourc_input.py
+++ b/tests/fourcipp/test_fourc_input.py
@@ -34,7 +34,7 @@ from fourcipp import CONFIG
 from fourcipp.fourc_input import (
     FourCInput,
     UnknownSectionException,
-    _sort_by_section_names,
+    sort_by_section_names,
 )
 from fourcipp.utils.cli import modify_input_with_defaults
 from fourcipp.utils.validation import ValidationError
@@ -593,7 +593,7 @@ def test_sort_by_section_names():
 
     shuffled_data = {k: 1 for k in shuffled_section_order}
 
-    sorted_data = _sort_by_section_names(shuffled_data)
+    sorted_data = sort_by_section_names(shuffled_data)
 
     assert list(sorted_data.keys()) == correct_section_order
 


### PR DESCRIPTION
In 3rd party projects new input file classes may inherit from FourCIPPs FourCInput.

If the dump functionality is overwritten it may look like this:

```python

from fourcipp.fourc_input import _sort_by_section_names

    def dump(
        self,
        input_file_path: str | _Path,
        *,
        nox_xml_file: str | None = None,
        add_header_default: bool = True,
        add_header_information: bool = True,
        add_footer_application_script: bool = True,
        validate=True,
        validate_sections_only: bool = False,
        sort_function: _Callable[[dict], dict] | None = _sort_by_section_names,
        fourcipp_yaml_style: bool = True,
    ):
    
    .....
    
        super().dump(
            input_file_path=input_file_path,
            validate=validate,
            validate_sections_only=validate_sections_only,
            convert_to_native_types=False,  # conversion already happens during add()
            sort_function=sort_function,
            use_fourcipp_yaml_style=fourcipp_yaml_style,
        )
```

This is necessary to be able to use the standard dump functionality of FourCIPP but still be able to overload it with a custom sorting function.

If one has to import the Python function from FourCIPP it is not very nice to import a "private" function.

To align with the other sort functions in `dict_utils` (which are also "public") this PR changes the name of the `sort_sections_by_name` function.