### PR TITLE
feat: use regex instead of re for better performance

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
-rapidyaml
-loguru
 jsonschema-rs
+loguru
 numpy
+rapidyaml
+regex

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ rapidyaml
     # manually removed version because on macos 0.9.0.post2 is latest
     # and on linux/windows 0.9.0 is latest
     # via -r requirements.in
+regex==2025.9.1
+    # via -r requirements.in

--- a/src/fourcipp/utils/yaml_io.py
+++ b/src/fourcipp/utils/yaml_io.py
@@ -23,9 +23,9 @@
 
 import json
 import pathlib
-import re
 from typing import Callable
 
+import regex
 import ryml
 
 from fourcipp.utils.typing import Path
@@ -50,12 +50,12 @@ def load_yaml(path_to_yaml_file: Path) -> dict:
     )
 
     # Convert `inf` to a string to avoid JSON parsing errors, see https://github.com/biojppm/rapidyaml/issues/312
-    json_str = re.sub(r":\s*(-?)inf\b", r': "\1inf"', json_str)
+    json_str = regex.sub(r":\s*(-?)inf\b", r': "\1inf"', json_str)
 
     # Convert floats that are missing digits on either side of the decimal point
     # so .5 to 0.5 and 5. to 5.0
-    json_str = re.sub(r":\s*(-?)\.([0-9]+)", r": \g<1>0.\2", json_str)
-    json_str = re.sub(r":\s*(-?)([0-9]+)\.(\D)", r": \1\2.0\3", json_str)
+    json_str = regex.sub(r":\s*(-?)\.([0-9]+)", r": \g<1>0.\2", json_str)
+    json_str = regex.sub(r":\s*(-?)([0-9]+)\.(\D)", r": \1\2.0\3", json_str)
 
     data = json.loads(json_str)
 
@@ -147,7 +147,7 @@ def dict_to_yaml_string(
 
     if use_fourcipp_yaml_style:
         # add spaces after commas in vectors
-        yaml_string = re.sub(r"(?<=\d),(?=\d)|(?<=\]),(?=\[)", ", ", yaml_string)
+        yaml_string = regex.sub(r"(?<=\d),(?=\d)|(?<=\]),(?=\[)", ", ", yaml_string)
 
     return yaml_string
 


### PR DESCRIPTION
Actually it makes a big difference if we use re or regex in our string replacement

For dumping a file with 100k elements and a total of 355k lines the timings look like this:

with re

<img width="1372" height="485" alt="Screenshot from 2025-09-04 13-02-42" src="https://github.com/user-attachments/assets/407d884b-5201-4ef3-b022-90591b0595c5" />


with regex

<img width="1372" height="485" alt="Screenshot from 2025-09-04 13-02-03" src="https://github.com/user-attachments/assets/4f03fc20-4e6b-4c94-be3f-c960213edb5b" />
