### PR TITLE
fix: add rapidyaml version again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,10 +14,7 @@ numpy==2.3.2
     # via -r requirements.in
 packaging==25.0
     # via deprecation
-rapidyaml
-    # TODO update requirements file
-    # manually removed version because on macos 0.9.0.post2 is latest
-    # and on linux/windows 0.9.0 is latest
+rapidyaml==0.10.0
     # via -r requirements.in
 regex==2025.9.1
     # via -r requirements.in


### PR DESCRIPTION
Closes #40 

New rapidyaml version just released => now we can add back the version again because the wheels are published for macOS, windows and Linux on the same version