### PR TITLE
fix: testing by extending reference_value_from_all_of for groups

### DIFF
--- a/tests/fourcipp/legacy_io/utils.py
+++ b/tests/fourcipp/legacy_io/utils.py
@@ -21,6 +21,8 @@
 # THE SOFTWARE.
 """Utils for legacy io testing."""
 
+from loguru import logger
+
 from fourcipp.legacy_io.element import to_dat_string
 
 # This map is used to generate elements from the metadata file
@@ -68,6 +70,11 @@ def reference_value_from_all_of(all_of):
             entry = [_TESTING_MAP[parameter["value_type"]["type"]]] * parameter["size"]
         elif parameter["type"] == "enum":
             entry = parameter["choices"][0]["name"]
+        elif parameter["type"] in ["selection", "group", "list", "all_of", "one_of"]:
+            logger.info(
+                f"The 4C legacy reader does not support parameters of type {parameter['type']}. Skipping the test for parameter \n{parameter}"
+            )
+            continue
         else:
             raise ValueError(f"Could not create testing line from {parameter['type']}")
 


### PR DESCRIPTION
Since the PR https://github.com/4C-multiphysics/4C/pull/1669 (@amgebauer) the metadata file changed accordingly (see automatic metadata file update in fourcipp (https://github.com/4C-multiphysics/fourcipp/commit/156c2245424b20bb0a42d90d0fda595f41b25efe).

Since then the testing pipeline of fourcipp fails because the reference elements cannot be created correctly.

This PR should fix this behaviour.