### PR TITLE
Add `None` to choices of optional enum in `metadata.py`

### DIFF
--- a/src/fourcipp/utils/metadata.py
+++ b/src/fourcipp/utils/metadata.py
@@ -365,7 +365,7 @@ class Primitive(InputSpec):
 class Enum(InputSpec):
     def __init__(
         self,
-        choices: Sequence[str],
+        choices: Sequence[str | None],
         name: NotSetAlias[str] = NotSetString,
         description: NotSetAlias[str] = NotSetString,
         required: bool = True,
@@ -385,6 +385,9 @@ class Enum(InputSpec):
             default: Default value
         """
         super().__init__("enum", name, description, required, noneable, validator)
+        if noneable:
+            # None is a valid value additionally if noneable
+            choices = list(choices) + [None]
         if check_if_set(default):
             if default not in choices:
                 raise ValueError(


### PR DESCRIPTION
This should fix #117.

The latest metadata change in 4C ([#1725](https://github.com/4C-multiphysics/4C/pull/1725)) fixed that optional enums need None (null in yaml) as a valid choice additionally. [#1688](https://github.com/4C-multiphysics/4C/pull/1688) used this feature for the first time, that's why it failed now.

This PR basically copies the changes made in 4C [#1725](https://github.com/4C-multiphysics/4C/pull/1725)

@davidrudlstorfer 