### PR TITLE
Add a CLI parameter for logging variables

### DIFF
--- a/src/fourcipp/__init__.py
+++ b/src/fourcipp/__init__.py
@@ -30,5 +30,4 @@ logger.disable("fourcipp")
 
 # Load the config
 CONFIG = load_config()
-
 logger.info(CONFIG)

--- a/src/fourcipp/utils/cli.py
+++ b/src/fourcipp/utils/cli.py
@@ -85,10 +85,10 @@ def format_file(
 
 def main() -> None:
     """Main CLI interface."""
-    # Set up the logger
-    logger.enable("fourcipp")
+    # Configure logger based on CLI args and configuration.
+    # First all existing loggers are removed
+    # and enabled only when logging is requested (see below).
     logger.remove()
-    logger.add(sys.stdout, format="{message}")
 
     # The FourCIPP CLI is build upon argparse and subparsers. The latter ones are use to interface
     # mutual exclusive commands. If you add a new command add a new subparser and add the CLI
@@ -148,9 +148,51 @@ def main() -> None:
         action="store_true",
         help=f"Overwrite existing input file.",
     )
-    # Replace "-" with "_" for variable names
+    # Add global CLI logging options
+    main_parser.add_argument(
+        "--log-file",
+        help="Path to log file. If set, enables file logging.",
+        type=str,
+        default=None,
+    )
+    main_parser.add_argument(
+        "--enable-log",
+        help="Enable logging to file according to configuration.",
+        action="store_true",
+    )
+
+    # Parse args and build kwargs for commands. Skip log-related global args.
+    parsed_args = main_parser.parse_args(sys.argv[1:])
+
+    # Determine whether logging should be enabled.
+    # When enabled, if a file path is provided use it
+    # and open with mode='w' (replace any existing file). Otherwise log to stdout.
+    try:
+        if getattr(parsed_args, "enable_log", False):
+            log_file_arg = getattr(parsed_args, "log_file", None)
+            logger.enable("fourcipp")
+            # Prefer CLI-specified path, then config path, otherwise stdout
+            if log_file_arg:
+                target = pathlib.Path(log_file_arg)
+                logger.add(
+                    target.as_posix(), mode="w", format="{time} {level} {message}"
+                )
+                logger.debug(f"Logging enabled to file: {target}")
+            else:
+                # No file path; log to stdout (screen)
+                logger.add(sys.stdout, format="{message}")
+                logger.debug("Logging enabled to stdout")
+        else:
+            # Keep package logging disabled
+            logger.disable("fourcipp")
+    except Exception:
+        logger.debug("Could not set up logging; continuing without logging.")
+        logger.disable("fourcipp")
+
     kwargs: dict = {}
-    for key, value in vars(main_parser.parse_args(sys.argv[1:])).items():
+    for key, value in vars(parsed_args).items():
+        if key in ("log_file", "enable_log"):
+            continue
         kwargs[key.replace("-", "_")] = value
     command = kwargs.pop("command")
 

--- a/src/fourcipp/utils/configuration.py
+++ b/src/fourcipp/utils/configuration.py
@@ -173,7 +173,6 @@ class ConfigProfile:
         s += add_keyword("4C metadata path", self.fourc_json_schema_path)
         s += add_keyword("4C JSON schema path", self.fourc_json_schema_path)
         s += add_keyword("User default path", self.user_defaults_path)
-
         return s
 
 


### PR DESCRIPTION
# Description

The 4Cipp code has a logging option, which is explicitly disabled in the code. I thought it is a good idea to have a command line switch to enable logging (to screen or to a file). This is what I propose in this PR. 
Please tell me whether you think it's useful. 

[Outdated, see below in the comments: The change in `yaml_io.py` is included because I got an error message when running 4Cipp, and the copilot told me this is caused by a misinterpretation of specific values for floats, which are now converted to `none`.  ]