### PR TITLE
Fix Python package license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ name = "FourCIPP"
 authors = [{ name = "FourCIPP Authors" }]
 description = "A streamlined Python Parser for 4C input files"
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dynamic = ["dependencies", "version"]
 


### PR DESCRIPTION
While working on fixing the automated license checking for [QUEENS](https://github.com/queens-py/queens), I stumbled upon an issue with FourCIPP’s package metadata: the project license was not being recognized correctly.

The reason might be that the license field in pyproject.toml was pointing to the license file directly, whereas Python packaging tooling expects this field to contain a machine-readable SPDX license expression. The actual license file should be exposed separately via license-files. I took this information from the [Python Packaging User Guide](https://packaging.python.org/en/latest/specifications/pyproject-toml/?utm_source=chatgpt.com#license).

This PR updates the metadata accordingly:
* set license = "MIT"
* add license-files = ["LICENSE"]

This should make the license information machine-readable and improve compatibility with tooling that inspects package metadata for automated license checks.