### PR TITLE
Test completion schema wrapper

### DIFF
--- a/.github/workflows/run_testsuite.yaml
+++ b/.github/workflows/run_testsuite.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run pytest with ${{ matrix.config_profile }} config
+        shell: bash
         run: |
           fourcipp switch-config-profile ${{ matrix.config_profile }}
           pytest --color=yes -v --performance-tests --no-cov

--- a/.github/workflows/run_testsuite.yaml
+++ b/.github/workflows/run_testsuite.yaml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.13"]
+        config_profile: [default, completion_schema]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -27,18 +28,22 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Run pytest with full schema
+      - name: Run pytest with ${{ matrix.config_profile }} config
         run: |
-          pytest --color=yes -v --performance-tests --no-cov
-          cat timings.md >> $GITHUB_STEP_SUMMARY
-      - name: Run pytest with completion-oriented schema
-        run: |
-          fourcipp switch-config-profile completion_schema
+          fourcipp switch-config-profile ${{ matrix.config_profile }}
           pytest --color=yes -v --performance-tests --no-cov
           cat timings.md >> $GITHUB_STEP_SUMMARY
 
   run_pytest_with_4C:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - fourc_config_profile: 4C_docker_main
+            pytest_config_profile: default
+          - fourc_config_profile: 4C_docker_main_completion_schema
+            pytest_config_profile: completion_schema
     container:
       image: ghcr.io/4c-multiphysics/4c:main
     steps:
@@ -48,22 +53,13 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           python-version: 3.13
-      - name: Run pytest using 4C_docker_main config
+      - name: Run pytest using {{ matrix.fourc_config_profile }} config
         run: |
-          fourcipp switch-config-profile 4C_docker_main
-          pytest -n 4 --color=yes -v
-      - name: Run pytest using 4C_docker_main_completion_schema config
-        run: |
-          fourcipp switch-config-profile 4C_docker_main_completion_schema
+          fourcipp switch-config-profile ${{ matrix.fourc_config_profile }}
           pytest -n 4 --color=yes -v
       - name: Run pytest using default config
         # For this job coverage is turned off, otherwise the checks would fail.
         # Coverage is done in the 4C docker job, as here 4C test input files are available.
         run: |
-          fourcipp switch-config-profile default
+          fourcipp switch-config-profile ${{ matrix.pytest_config_profile }}
           pytest -n 4 --color=yes -v --no-cov
-      - name: Run pytest with completion_schema config
-        run: |
-          fourcipp switch-config-profile completion_schema
-          pytest --color=yes -v --performance-tests --no-cov
-          cat timings.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/run_testsuite.yaml
+++ b/.github/workflows/run_testsuite.yaml
@@ -53,13 +53,25 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           python-version: 3.13
-      - name: Run pytest using {{ matrix.fourc_config_profile }} config
+      - name: Run pytest using ${{ matrix.fourc_config_profile }} config
         run: |
           fourcipp switch-config-profile ${{ matrix.fourc_config_profile }}
           pytest -n 4 --color=yes -v
-      - name: Run pytest using default config
+      - name: Run pytest using ${{ matrix.pytest_config_profile }} config
         # For this job coverage is turned off, otherwise the checks would fail.
         # Coverage is done in the 4C docker job, as here 4C test input files are available.
         run: |
           fourcipp switch-config-profile ${{ matrix.pytest_config_profile }}
           pytest -n 4 --color=yes -v --no-cov
+
+  ensure_all_tests_pass:
+    runs-on: ubuntu-latest
+    needs:
+      - run_pytest
+      - run_pytest_with_4C
+    if: always()
+    steps:
+      - name: Check matrix results
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/run_testsuite.yaml
+++ b/.github/workflows/run_testsuite.yaml
@@ -27,8 +27,13 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Run pytest
+      - name: Run pytest with full schema
         run: |
+          pytest --color=yes -v --performance-tests --no-cov
+          cat timings.md >> $GITHUB_STEP_SUMMARY
+      - name: Run pytest with completion-oriented schema
+        run: |
+          fourcipp switch-config-profile completion_schema
           pytest --color=yes -v --performance-tests --no-cov
           cat timings.md >> $GITHUB_STEP_SUMMARY
 
@@ -47,9 +52,18 @@ jobs:
         run: |
           fourcipp switch-config-profile 4C_docker_main
           pytest -n 4 --color=yes -v
+      - name: Run pytest using 4C_docker_main_completion_schema config
+        run: |
+          fourcipp switch-config-profile 4C_docker_main_completion_schema
+          pytest -n 4 --color=yes -v
       - name: Run pytest using default config
         # For this job coverage is turned off, otherwise the checks would fail.
         # Coverage is done in the 4C docker job, as here 4C test input files are available.
         run: |
           fourcipp switch-config-profile default
           pytest -n 4 --color=yes -v --no-cov
+      - name: Run pytest with completion_schema config
+        run: |
+          fourcipp switch-config-profile completion_schema
+          pytest --color=yes -v --performance-tests --no-cov
+          cat timings.md >> $GITHUB_STEP_SUMMARY

--- a/src/fourcipp/config/config.yaml
+++ b/src/fourcipp/config/config.yaml
@@ -5,8 +5,18 @@ profiles:
     fourc_json_schema_path: "4C_schema.json"
     description: "Profile for the latest successful nightly 4C build"
     user_defaults_path: null
+  completion_schema:
+    fourc_metadata_path: "4C_metadata.yaml"
+    fourc_json_schema_path: "4C_schema_completion.json"
+    description: "Profile for the completion-oriented schema of the latest successful nightly 4C build. Note: this schema wraps the full schema, so it relies on the full schema being present in the same directory."
+    user_defaults_path: null
   4C_docker_main:
     fourc_metadata_path: "/home/user/4C/build/4C_metadata.yaml"
     fourc_json_schema_path: "/home/user/4C/build/4C_schema.json"
     description: "Profile for the 4C docker build main"
+    user_defaults_path: null
+  4C_docker_main_completion_schema:
+    fourc_metadata_path: "/home/user/4C/build/4C_metadata.yaml"
+    fourc_json_schema_path: "/home/user/4C/build/4C_schema_completion.json"
+    description: "Profile for the 4C docker build main for the completion-oriented schema."
     user_defaults_path: null

--- a/src/fourcipp/fourc_input.py
+++ b/src/fourcipp/fourc_input.py
@@ -90,7 +90,7 @@ def sort_by_section_names(data: dict) -> dict:
         Dict sorted in 4C fashion
     """
 
-    required_sections = CONFIG.fourc_json_schema["required"]
+    required_sections = CONFIG.required_sections
     n_sections_splitter = len(CONFIG.sections.all_sections) * 1000
 
     # typed sections (sorted alphabetically + case insensitive, 'DESIGN *' + 'MATERIALS' at the end)
@@ -546,30 +546,30 @@ class FourCInput:
 
     def validate(
         self,
-        json_schema: dict = CONFIG.fourc_json_schema,
         sections_only: bool = False,
         convert_to_native_types: bool = True,
     ) -> bool:
         """Validate input file.
 
         Args:
-            json_schema: Schema to check the data
             sections_only: Validate each section independently.
                 Requiredness of the sections themselves is ignored.
             convert_to_native_types: Convert all sections to native Python types
         """
-        validation_schema = json_schema
-
-        # Remove the requiredness of the sections
-        if sections_only:
-            validation_schema = json_schema.copy()
-            validation_schema.pop("required")
 
         if convert_to_native_types:
             self.convert_to_native_types()
 
         # Validate sections using schema
-        validate_using_json_schema(self._sections, validation_schema)
+        if sections_only:
+            validator = CONFIG.sections_only_validator
+        else:
+            validator = CONFIG.validator
+
+        validate_using_json_schema(
+            self._sections,
+            validator=validator,
+        )
 
         # Legacy sections are only checked if they are of type string
         for section_name, section in inline_legacy_sections(

--- a/src/fourcipp/utils/configuration.py
+++ b/src/fourcipp/utils/configuration.py
@@ -27,6 +27,7 @@ import copy
 import pathlib
 from dataclasses import dataclass, field
 
+import jsonschema_rs
 from loguru import logger
 
 from fourcipp.utils.type_hinting import Path, T
@@ -87,6 +88,13 @@ class ConfigProfile:
     user_defaults_path: Path | None = None
     fourc_metadata: dict = field(init=False)
     fourc_json_schema: dict = field(init=False)
+    required_sections: list[str] = field(init=False)
+    _validator: jsonschema_rs.Validator | None = field(
+        default=None, init=False, repr=False
+    )
+    _sections_only_validator: jsonschema_rs.Validator | None = field(
+        default=None, init=False, repr=False
+    )
     sections: Sections = field(init=False)
 
     def __post_init__(self) -> None:
@@ -98,8 +106,13 @@ class ConfigProfile:
         self.sections = Sections.from_metadata(self.fourc_metadata)
 
         self.fourc_json_schema_path = pathlib.Path(self.fourc_json_schema_path)
+        if not self.fourc_json_schema_path.is_absolute():
+            self.fourc_json_schema_path = CONFIG_PACKAGE / self.fourc_json_schema_path
         self.fourc_json_schema = ConfigProfile._load_data_from_path(
             self.fourc_json_schema_path
+        )
+        self.required_sections = ConfigProfile._resolve_required_sections(
+            self.fourc_json_schema, self.fourc_json_schema_path
         )
 
         if self.user_defaults_path is not None:
@@ -108,6 +121,82 @@ class ConfigProfile:
                 raise FileNotFoundError(
                     f"User defaults file '{self.user_defaults_path}' does not exist."
                 )
+
+    @property
+    def validator(self) -> jsonschema_rs.Validator:
+        """JSON schema validator for complete input files."""
+        if self._validator is None:
+            self._validator = jsonschema_rs.validator_for(
+                self.fourc_json_schema,
+                base_uri=pathlib.Path(self.fourc_json_schema_path).as_uri(),
+            )
+
+        return self._validator
+
+    @property
+    def sections_only_validator(self) -> jsonschema_rs.Validator:
+        """JSON schema validator for independent section validation."""
+        if self._sections_only_validator is None:
+            schema_without_required_sections = ConfigProfile._remove_required_sections(
+                self.fourc_json_schema,
+                self.fourc_json_schema_path,
+            )
+            self._sections_only_validator = jsonschema_rs.validator_for(
+                schema_without_required_sections,
+                base_uri=pathlib.Path(self.fourc_json_schema_path).as_uri(),
+            )
+
+        return self._sections_only_validator
+
+    @staticmethod
+    def _resolve_required_sections(json_schema: dict, schema_path: Path) -> list[str]:
+        """Resolve required top-level sections from a schema or schema
+        wrapper."""
+        if "required" in json_schema:
+            return list(json_schema["required"])
+
+        for clause in json_schema.get("allOf", []):
+            ref = clause.get("$ref")
+            if isinstance(ref, str) and not ref.startswith("#"):
+                referenced_schema = ConfigProfile._load_data_from_path(
+                    ConfigProfile._resolve_schema_ref(ref, schema_path)
+                )
+                return list(referenced_schema.get("required", []))
+
+        return []
+
+    @staticmethod
+    def _remove_required_sections(json_schema: dict, schema_path: Path) -> dict:
+        """Create a schema for section-only validation.
+
+        Schemas with top-level required entries are treated as non-wrapper
+        schemas and use a shallow copy with those entries removed. Otherwise,
+        the schema is treated as a completion wrapper and direct external refs
+        in ``allOf`` are replaced by shallow-copied referenced schemas with
+        their top-level required entries removed.
+        """
+        validation_schema = json_schema.copy()
+        if "required" in validation_schema:
+            validation_schema.pop("required")
+            return validation_schema
+
+        all_of = []
+        for subschema in json_schema.get("allOf", []):
+            ref = subschema.get("$ref")
+            if ref is None:
+                all_of.append(subschema.copy())
+                continue
+
+            referenced_schema = ConfigProfile._load_data_from_path(
+                ConfigProfile._resolve_schema_ref(ref, schema_path)
+            ).copy()
+            referenced_schema.pop("required", None)
+            all_of.append(referenced_schema)
+
+        if all_of:
+            validation_schema["allOf"] = all_of
+
+        return validation_schema
 
     @staticmethod
     def _load_data_from_path(path: Path) -> dict:
@@ -119,6 +208,14 @@ class ConfigProfile:
             )
             path = CONFIG_PACKAGE / path
         return load_yaml(path)
+
+    @staticmethod
+    def _resolve_schema_ref(ref: str, schema_path: Path) -> Path:
+        """Resolve a JSON schema ref path relative to the schema file."""
+        ref_path = pathlib.Path(ref)
+        if ref_path.is_absolute():
+            return ref_path
+        return pathlib.Path(schema_path).parent / ref_path
 
     @staticmethod
     def _resolve_references(metadata_dict: dict) -> dict:

--- a/src/fourcipp/utils/validation.py
+++ b/src/fourcipp/utils/validation.py
@@ -128,17 +128,20 @@ def find_keys_exceeding_max_value(
         yield path_for_data, obj
 
 
-def validate_using_json_schema(data: dict, json_schema: dict) -> bool:
+def validate_using_json_schema(
+    data: dict,
+    validator: jsonschema_rs.Validator,
+) -> bool:
     """Validate data using a JSON schema.
 
     Args:
         data: Data to validate
-        json_schema: Schema for validation
+        validator: Validator for validation
 
     Returns:
         True if successful
     """
-    validator = jsonschema_rs.validator_for(json_schema)
+
     try:
         validator.validate(data)
     except jsonschema_rs.ValidationError as exception:

--- a/tests/fourcipp/test_fourc_input.py
+++ b/tests/fourcipp/test_fourc_input.py
@@ -575,13 +575,14 @@ def test_validation(fourc_input, error_context, sections_only):
 
 def test_sort_by_section_names():
     """Test sorting by section names."""
+    required_sections = CONFIG.required_sections
 
     # create list of typed sections without title and required sections
     typed_sections = [
         sec
         for sec in CONFIG.sections.typed_sections
         if sec != CONFIG.fourc_metadata["metadata"]["description_section_name"]
-        and sec not in set(CONFIG.fourc_json_schema["required"])
+        and sec not in set(required_sections)
     ]
 
     # also use end subset to also add some lowercase sections
@@ -599,7 +600,7 @@ def test_sort_by_section_names():
 
     correct_section_order = (
         [CONFIG.fourc_metadata["metadata"]["description_section_name"]]
-        + CONFIG.fourc_json_schema["required"]
+        + required_sections
         + typed_sections
         + ["MATERIALS"]
         + design_sections

--- a/tests/fourcipp/test_fourc_input.py
+++ b/tests/fourcipp/test_fourc_input.py
@@ -439,7 +439,11 @@ class SubprocessError(Exception):
     """Subprocess failure."""
 
 
-@pytest.mark.skipif(CONFIG.name != "4C_docker_main", reason="Not using docker config.")
+@pytest.mark.skipif(
+    not CONFIG.name == "4C_docker_main"
+    and not CONFIG.name == "4C_docker_main_completion_schema",
+    reason="Not using docker config.",
+)
 @pytest.mark.parametrize("fourc_file", FOURC_TEST_INPUT_FILES)
 def test_roundtrip_test(fourc_file, tmp_path):
     """Roundtrip test."""
@@ -469,7 +473,11 @@ def test_roundtrip_test(fourc_file, tmp_path):
         )
 
 
-@pytest.mark.skipif(CONFIG.name != "4C_docker_main", reason="Not using docker config.")
+@pytest.mark.skipif(
+    not CONFIG.name == "4C_docker_main"
+    and not CONFIG.name == "4C_docker_main_completion_schema",
+    reason="Not using docker config.",
+)
 @pytest.mark.parametrize(
     "fourc_file",
     [


### PR DESCRIPTION
Relies on merging and nightly update of #135.

Changes:
- Does all the python changes necessary to also test a schema wrapper referencing another schema. Some of these changes were also already required in 4C-multiphysics/4C#2006. The resolution of `required` section in the completion schema needed special treatment, so I adapted that.
- Add two new configs referencing the completion schema, one for the completion schema that lives in fourcipp, one for the 4C docker container.
- Use these configs for testing (PR and nightly)
- Add a current completion schema. This is just to see if the normal non-docker tests are passing, which they do. The docker test relies on the updated 4C docker container. After #135, this last commit is no longer required.