### PR TITLE
Fix schema updating rule

### DIFF
--- a/.github/workflows/update_4C_metadata_schema_file.yaml
+++ b/.github/workflows/update_4C_metadata_schema_file.yaml
@@ -58,8 +58,8 @@ jobs:
 
           metadata_hash_current=$(grep -v 'commit_hash' src/fourcipp/config/4C_metadata.yaml | sha256sum | awk '{print $1}')
           metadata_hash_new=$(grep -v 'commit_hash' clang18_build-metadata/4C_metadata.yaml | sha256sum | awk '{print $1}')
-          schema_hash_current=$(sha256sum src/fourcipp/config/4C_schema.json | awk '{print $1}')
-          schema_hash_new=$(sha256sum clang18_build-schema/4C_schema.json | awk '{print $1}')
+          schema_hash_current=$(grep -v -E 'Commit hash|\$id' src/fourcipp/config/4C_schema.json | sha256sum | awk '{print $1}')
+          schema_hash_new=$(grep -v -E 'Commit hash|\$id' clang18_build-schema/4C_schema.json | sha256sum | awk '{print $1}')
           completion_schema_hash_current=$(sha256sum src/fourcipp/config/4C_schema_completion.json | awk '{print $1}')
           completion_schema_hash_new=$(sha256sum clang18_build-completion-schema/4C_schema_completion.json | awk '{print $1}')
 


### PR DESCRIPTION
All lines containing the commit hash are now removed from the sha256sum computation. This means that only actual schema changes will trigger a new version tag and schema update.

The completion schema does not contain the 4C commit hash, so no action required there. 

Note: there will be one last seemingly unnecessary update because the commit hash removal will lead to a different sha256sum. Afterwards it should be fine.

Closes #137